### PR TITLE
fullClone fixes

### DIFF
--- a/example-apps/meteor-blaze-app/imports/client/images/images.css
+++ b/example-apps/meteor-blaze-app/imports/client/images/images.css
@@ -8,3 +8,11 @@
   width: 300px;
   max-width: 300px;
 }
+
+.btn-row {
+  margin: -2px 0;
+}
+
+.btn-row > .btn {
+  margin: 2px 0;
+}

--- a/example-apps/meteor-blaze-app/imports/client/images/images.html
+++ b/example-apps/meteor-blaze-app/imports/client/images/images.html
@@ -27,8 +27,11 @@
       <p><em>Original upload: {{this.name}}, {{this.type}}, {{this.size}} bytes</em></p>
       <p><em>File saved to "images" store: {{nameForStore 'images'}}, {{typeForStore 'images'}}, {{sizeForStore 'images'}} bytes</em></p>
       <p><em>File saved to "thumbs" store: {{nameForStore 'thumbs'}}, {{typeForStore 'thumbs'}}, {{sizeForStore 'thumbs'}} bytes</em></p>
-      <a href="{{downloadUrlForStore 'images'}}" class="btn btn-default btn-xs" role="button" target="_blank">Download</a>
-      <button type="button" class="js-deleteFile btn btn-danger btn-xs">Delete</button>
+      <div class="btn-row">
+        <a href="{{downloadUrlForStore 'images'}}" class="btn btn-default btn-xs" role="button" target="_blank">Download</a>
+        <button type="button" class="js-cloneFile btn btn-default btn-xs">Clone</button>
+        <button type="button" class="js-deleteFile btn btn-danger btn-xs">Delete</button>
+      </div>
     </div>
   </div>
 </template>

--- a/example-apps/meteor-blaze-app/imports/client/images/images.js
+++ b/example-apps/meteor-blaze-app/imports/client/images/images.js
@@ -85,5 +85,8 @@ Template.images.events({
   },
   "click .js-deleteFile"() {
     Meteor.call("removeImage", this._id);
+  },
+  "click .js-cloneFile"() {
+    Meteor.call("cloneImage", this._id);
   }
 });

--- a/example-apps/meteor-blaze-app/server/main.js
+++ b/example-apps/meteor-blaze-app/server/main.js
@@ -109,6 +109,14 @@ Meteor.methods({
     const images = Promise.await(Images.find());
     const result = Promise.await(Promise.all(images.map((fileRecord) => Images.remove(fileRecord))));
     return result;
+  },
+  cloneImage(id) {
+    const fileRecord = Promise.await(Images.findOne(id));
+    if (!fileRecord) throw new Meteor.Error("not-found", `No FileRecord has ID ${id}`);
+
+    // The side effect of this call should be that a new file record now
+    // exists with data in both stores, and will be autopublished to the client.
+    Promise.await(fileRecord.fullClone());
   }
 });
 

--- a/packages/file-collections/src/common/FileRecord/FileRecord.js
+++ b/packages/file-collections/src/common/FileRecord/FileRecord.js
@@ -297,9 +297,9 @@ export default class FileRecord extends EventEmitter {
       // rather than createReadStream in order to bypass any potential transformRead function
       const readStream = await store.createReadStreamForFileKey(store.fileKey(this));
 
-      // Get the writeStream to write back in for the clone. We use createWriteStreamForFileKey
-      // rather than createWriteStream in order to bypass any potential transformWrite function
-      const writeStream = await store.createWriteStreamForFileKey(store.fileKey(cloneRecord));
+      // Get the writeStream to write back in for the clone. Skip transforms because we are writing
+      // file data that was already transformed when originally saved.
+      const writeStream = await store.createWriteStream(cloneRecord, { skipTransform: true });
 
       return new Promise((resolve, reject) => {
         writeStream.once("error", reject);

--- a/packages/file-collections/src/node/MeteorFileCollection.js
+++ b/packages/file-collections/src/node/MeteorFileCollection.js
@@ -106,8 +106,8 @@ export default class MeteorFileCollection extends FileCollection {
   async _insert(doc) {
     // Generate string ID to avoid getting a Mongo ObjectID
     if (!doc._id) doc._id = this.mongoCollection._makeNewID();
-    const id = await this.insertPromise(doc);
-    return this._findOne(id);
+    await this.insertPromise(doc);
+    return this._findOne(doc._id);
   }
 
   /**


### PR DESCRIPTION
Previously, `fullClone` did not work. There were two issues, which are now fixed.

- In `MeteorFileCollection`, `_insert` now correctly returns the inserted document.
- In `FileRecord`, `fullClone` now uses `createWriteStream` instead of `createWriteStreamForFileKey`, but I've added a `skipTransform` option. The only reason we were using `createWriteStreamForFileKey` was to skip the transform, but this was skipping saving the copy info, too.