### PR TITLE
feat: add MongoFileCollection class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -150,53 +150,6 @@
       "integrity": "sha512-Lpq/k4UzyUDyXeysZT+o+VMNi8BUTVoM+IfdvYL+7mpNiGYhj3BCprapOZget1t7V11TIxbxSL2wTXvRFP5JaQ==",
       "dev": true
     },
-    "@semantic-release/commit-analyzer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-2.0.0.tgz",
-      "integrity": "sha1-kk0eLDAWfGpHK+2fZu6Pjgd0ibI=",
-      "dev": true,
-      "requires": {
-        "conventional-changelog": "0.0.17"
-      }
-    },
-    "@semantic-release/condition-travis": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/condition-travis/-/condition-travis-5.0.2.tgz",
-      "integrity": "sha1-9Lt3emxttVZdcHVKm2KSM71KZZc=",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "1.0.0",
-        "semver": "5.5.0",
-        "travis-deploy-once": "1.0.0-node-0.10-support"
-      }
-    },
-    "@semantic-release/error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-1.0.0.tgz",
-      "integrity": "sha1-u4+O7t1cf4xG+Ws37znhuMN2wcw=",
-      "dev": true
-    },
-    "@semantic-release/last-release-npm": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/last-release-npm/-/last-release-npm-1.2.1.tgz",
-      "integrity": "sha1-/3SBQuzxU1S4M6hroYIF9/zllO4=",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "1.0.0",
-        "npm-registry-client": "7.5.0",
-        "npmlog": "1.2.1"
-      }
-    },
-    "@semantic-release/release-notes-generator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-2.0.0.tgz",
-      "integrity": "sha1-fF2mVolGbVNqU/36n01io70TwW4=",
-      "dev": true,
-      "requires": {
-        "conventional-changelog": "0.0.17",
-        "github-url-from-git": "1.5.0"
-      }
-    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -211,12 +164,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
-      "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "acorn": {
@@ -257,24 +204,6 @@
       "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
       "dev": true
     },
-    "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-      "dev": true,
-      "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        }
-      }
-    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -308,12 +237,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
-    "ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
       "dev": true
     },
     "ansi-escapes": {
@@ -1401,43 +1324,6 @@
       "dev": true,
       "optional": true
     },
-    "bl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
-    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -1694,12 +1580,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-      "dev": true
-    },
     "columnify": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
@@ -1758,16 +1638,6 @@
         "typedarray": "0.0.6"
       }
     },
-    "config-chain": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-      "dev": true,
-      "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
-      }
-    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -1785,44 +1655,6 @@
       "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
       "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
       "dev": true
-    },
-    "conventional-changelog": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.17.tgz",
-      "integrity": "sha1-XgIWYA9GhhkPDILvuws90RtJzjQ=",
-      "dev": true,
-      "requires": {
-        "dateformat": "1.0.12",
-        "event-stream": "3.3.4",
-        "github-url-from-git": "1.5.0",
-        "lodash": "3.10.1",
-        "normalize-package-data": "1.0.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
-          "integrity": "sha1-i+lVuJB6+XXxpFhOqLubQUkjEvU=",
-          "dev": true,
-          "requires": {
-            "github-url-from-git": "1.5.0",
-            "github-url-from-username-repo": "1.0.2",
-            "semver": "4.3.6"
-          }
-        },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
-        }
-      }
     },
     "conventional-changelog-angular": {
       "version": "1.6.4",
@@ -2119,12 +1951,6 @@
         "array-find-index": "1.0.2"
       }
     },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
-      "dev": true
-    },
     "damerau-levenshtein": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
@@ -2261,16 +2087,6 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
-    },
-    "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dev": true,
-      "requires": {
-        "asap": "2.0.6",
-        "wrappy": "1.0.2"
-      }
     },
     "diff": {
       "version": "3.4.0",
@@ -2723,21 +2539,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
-      }
-    },
     "exec-sh": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
@@ -2841,12 +2642,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
     "fast-deep-equal": {
@@ -2968,16 +2763,6 @@
         "write": "0.2.1"
       }
     },
-    "follow-redirects": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "stream-consume": "0.1.0"
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2999,12 +2784,6 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
-    "foreachasync": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
-      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=",
-      "dev": true
-    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3021,21 +2800,6 @@
         "combined-stream": "1.0.6",
         "mime-types": "2.1.17"
       }
-    },
-    "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.1.2"
-      }
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
     },
     "fs-extra": {
       "version": "4.0.3",
@@ -4014,21 +3778,6 @@
         }
       }
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -4075,15 +3824,6 @@
         "assert-plus": "1.0.0"
       }
     },
-    "git-head": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/git-head/-/git-head-1.14.0.tgz",
-      "integrity": "sha1-vjHBB/uEAgmFYSUO8enYiELDkbg=",
-      "dev": true,
-      "requires": {
-        "git-refs": "1.1.3"
-      }
-    },
     "git-raw-commits": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.2.tgz",
@@ -4095,17 +3835,6 @@
         "meow": "3.7.0",
         "split2": "2.2.0",
         "through2": "2.0.3"
-      }
-    },
-    "git-refs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/git-refs/-/git-refs-1.1.3.tgz",
-      "integrity": "sha1-gwl8s6klhcSkkm7FTiGC354g6J0=",
-      "dev": true,
-      "requires": {
-        "path-object": "2.3.0",
-        "slash": "1.0.0",
-        "walk": "2.3.9"
       }
     },
     "git-remote-origin-url": {
@@ -4136,30 +3865,6 @@
       "requires": {
         "ini": "1.3.5"
       }
-    },
-    "github": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/github/-/github-8.2.1.tgz",
-      "integrity": "sha1-YWsiEfvNHMhjFmmu1nZT5i61OBY=",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "0.0.7",
-        "https-proxy-agent": "1.0.0",
-        "mime": "1.6.0",
-        "netrc": "0.1.4"
-      }
-    },
-    "github-url-from-git": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
-      "dev": true
-    },
-    "github-url-from-username-repo": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
-      "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
-      "dev": true
     },
     "glob": {
       "version": "7.1.2",
@@ -4374,17 +4079,6 @@
         "sshpk": "1.13.1"
       }
     },
-    "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "dev": true,
-      "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -4529,12 +4223,6 @@
         }
       }
     },
-    "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
-      "dev": true
-    },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
@@ -4659,25 +4347,6 @@
         "is-extglob": "1.0.0"
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -4739,12 +4408,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-redirect": {
@@ -6007,12 +5670,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6382,158 +6039,6 @@
         }
       }
     },
-    "lerna-semantic-release": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/lerna-semantic-release/-/lerna-semantic-release-9.1.0.tgz",
-      "integrity": "sha1-vJLd04b3mSpOV3UccPqYK9XCxQs=",
-      "dev": true,
-      "requires": {
-        "lerna-semantic-release-io": "7.0.2",
-        "lerna-semantic-release-perform": "4.1.0",
-        "lerna-semantic-release-post": "6.0.0",
-        "lerna-semantic-release-pre": "4.1.1",
-        "lerna-semantic-release-utils": "4.0.15",
-        "meow": "3.7.0"
-      }
-    },
-    "lerna-semantic-release-analyze-commits": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lerna-semantic-release-analyze-commits/-/lerna-semantic-release-analyze-commits-4.2.1.tgz",
-      "integrity": "sha1-FjU1Feujq430VOhWLQ0FiVDzzHk=",
-      "dev": true,
-      "requires": {
-        "@semantic-release/commit-analyzer": "2.0.0",
-        "lerna-semantic-release-utils": "4.0.15"
-      }
-    },
-    "lerna-semantic-release-get-last-release": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/lerna-semantic-release-get-last-release/-/lerna-semantic-release-get-last-release-5.0.13.tgz",
-      "integrity": "sha1-AkFuT48RkRw3TrKyZPSKyNWNJFg=",
-      "dev": true,
-      "requires": {
-        "lerna-semantic-release-utils": "4.0.15"
-      }
-    },
-    "lerna-semantic-release-io": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/lerna-semantic-release-io/-/lerna-semantic-release-io-7.0.2.tgz",
-      "integrity": "sha1-71pNTiLnjhzposjZXTMZHk9ZLro=",
-      "dev": true,
-      "requires": {
-        "@semantic-release/last-release-npm": "1.2.1",
-        "git-head": "1.14.0",
-        "lerna-semantic-release-analyze-commits": "4.2.1",
-        "lerna-semantic-release-get-last-release": "5.0.13",
-        "lerna-semantic-release-utils": "4.0.15",
-        "mock-fs": "3.11.0",
-        "mockery": "1.7.0",
-        "semantic-release": "6.3.6",
-        "shelljs": "0.7.8",
-        "simple-git": "1.48.0",
-        "sinon": "1.17.7"
-      }
-    },
-    "lerna-semantic-release-perform": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lerna-semantic-release-perform/-/lerna-semantic-release-perform-4.1.0.tgz",
-      "integrity": "sha1-OnD/Mo9kSbXYCT1god8+6GGWHr0=",
-      "dev": true,
-      "requires": {
-        "async": "2.6.0",
-        "lerna-semantic-release-io": "7.0.2",
-        "lerna-semantic-release-utils": "4.0.15"
-      }
-    },
-    "lerna-semantic-release-post": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lerna-semantic-release-post/-/lerna-semantic-release-post-6.0.0.tgz",
-      "integrity": "sha1-qkdDci2QRbvAUBeRAFYwsiLIjDs=",
-      "dev": true,
-      "requires": {
-        "conventional-changelog": "1.1.15",
-        "dateformat": "1.0.12",
-        "lerna-semantic-release-analyze-commits": "4.2.1",
-        "lerna-semantic-release-io": "7.0.2",
-        "lerna-semantic-release-utils": "4.0.15"
-      },
-      "dependencies": {
-        "conventional-changelog": {
-          "version": "1.1.15",
-          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.15.tgz",
-          "integrity": "sha512-nBHfdoIfm78Bh/8KAEKVjAfr6jT6+uAoayj8EpEIEpjXBwoB74FlC7hUDwbxbAA/WKZout8SuqnpPH0cX4/aqw==",
-          "dev": true,
-          "requires": {
-            "conventional-changelog-angular": "1.6.4",
-            "conventional-changelog-atom": "0.2.2",
-            "conventional-changelog-codemirror": "0.3.2",
-            "conventional-changelog-core": "2.0.3",
-            "conventional-changelog-ember": "0.3.4",
-            "conventional-changelog-eslint": "1.0.2",
-            "conventional-changelog-express": "0.3.2",
-            "conventional-changelog-jquery": "0.1.0",
-            "conventional-changelog-jscs": "0.1.0",
-            "conventional-changelog-jshint": "0.3.2",
-            "conventional-changelog-preset-loader": "1.1.4"
-          }
-        }
-      }
-    },
-    "lerna-semantic-release-pre": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lerna-semantic-release-pre/-/lerna-semantic-release-pre-4.1.1.tgz",
-      "integrity": "sha1-nOipBxsm8yqmlJhiD+fcNyWNr4Y=",
-      "dev": true,
-      "requires": {
-        "async": "2.0.1",
-        "lerna-semantic-release-io": "6.0.1",
-        "lerna-semantic-release-utils": "4.0.15",
-        "npmconf": "2.1.2",
-        "rc": "1.1.7",
-        "semantic-release": "6.3.6"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
-          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.5"
-          }
-        },
-        "lerna-semantic-release-io": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/lerna-semantic-release-io/-/lerna-semantic-release-io-6.0.1.tgz",
-          "integrity": "sha1-VjnplXiV6zXf9SKeb8B7kBdazdY=",
-          "dev": true,
-          "requires": {
-            "@semantic-release/last-release-npm": "1.2.1",
-            "git-head": "1.14.0",
-            "lerna-semantic-release-analyze-commits": "4.2.1",
-            "lerna-semantic-release-get-last-release": "5.0.13",
-            "lerna-semantic-release-utils": "4.0.15",
-            "mock-fs": "3.11.0",
-            "mockery": "1.7.0",
-            "semantic-release": "6.3.6",
-            "shelljs": "0.7.8",
-            "simple-git": "1.48.0",
-            "sinon": "1.17.7"
-          }
-        }
-      }
-    },
-    "lerna-semantic-release-utils": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/lerna-semantic-release-utils/-/lerna-semantic-release-utils-4.0.15.tgz",
-      "integrity": "sha1-V/qbbTDfRB4gsgRTXsgodnlvSGk=",
-      "dev": true,
-      "requires": {
-        "async": "2.6.0",
-        "shelljs": "0.7.8",
-        "winston": "2.4.0"
-      }
-    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -6579,119 +6084,16 @@
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
       "dev": true
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-      "dev": true
-    },
-    "lodash._createassigner": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dev": true,
-      "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
-      }
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
-    "lodash.assign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
     "lodash.cond": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
-      "dev": true
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
-    },
-    "lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
-      "dev": true
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "dev": true
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-      "dev": true
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.sortby": {
@@ -6718,12 +6120,6 @@
       "requires": {
         "lodash._reinterpolate": "3.0.0"
       }
-    },
-    "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
-      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -6798,12 +6194,6 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-      "dev": true
-    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -6875,12 +6265,6 @@
         "regex-cache": "0.4.4"
       }
     },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true
-    },
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
@@ -6926,30 +6310,6 @@
         "minimist": "0.0.8"
       }
     },
-    "mock-fs": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-3.11.0.tgz",
-      "integrity": "sha1-CW8h3+mFGJoKbvxLOM60BO6OiRE=",
-      "dev": true,
-      "requires": {
-        "rewire": "2.5.2",
-        "semver": "5.1.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
-          "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk=",
-          "dev": true
-        }
-      }
-    },
-    "mockery": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
-      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8=",
-      "dev": true
-    },
     "modify-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
@@ -6987,18 +6347,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "nerf-dart": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
-      "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
-      "dev": true
-    },
-    "netrc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
-      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
-      "dev": true
-    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -7027,16 +6375,6 @@
         "which": "1.3.0"
       }
     },
-    "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.1.1",
-        "osenv": "0.1.4"
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -7058,49 +6396,6 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
-    "npm-package-arg": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.1.tgz",
-      "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "semver": "5.5.0"
-      }
-    },
-    "npm-registry-client": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.5.0.tgz",
-      "integrity": "sha1-D23W5dEUJM+pn85bkw/q8JtPfwQ=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.0",
-        "graceful-fs": "4.1.11",
-        "normalize-package-data": "2.4.0",
-        "npm-package-arg": "4.2.1",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "request": "2.83.0",
-        "retry": "0.10.1",
-        "semver": "5.5.0",
-        "slide": "1.1.6"
-      },
-      "dependencies": {
-        "npmlog": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        }
-      }
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -7108,85 +6403,6 @@
       "dev": true,
       "requires": {
         "path-key": "2.0.1"
-      }
-    },
-    "npmconf": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
-      "integrity": "sha1-ZmBqSnNvHnegWaoHGnnJSreBhTo=",
-      "dev": true,
-      "requires": {
-        "config-chain": "1.1.11",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.3.3",
-        "osenv": "0.1.4",
-        "semver": "4.3.6",
-        "uid-number": "0.0.5"
-      },
-      "dependencies": {
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1"
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
-        }
-      }
-    },
-    "npmlog": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-      "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
-      "dev": true,
-      "requires": {
-        "ansi": "0.3.1",
-        "are-we-there-yet": "1.0.6",
-        "gauge": "1.2.7"
-      },
-      "dependencies": {
-        "are-we-there-yet": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-          "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
-          "dev": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-          "dev": true,
-          "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "2.0.1",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
-          }
-        }
       }
     },
     "number-is-nan": {
@@ -7329,16 +6545,6 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
-    "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
     "output-file-sync": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
@@ -7455,16 +6661,6 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
-    "path-object": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/path-object/-/path-object-2.3.0.tgz",
-      "integrity": "sha1-A+RmU+XDdcYK8cq92UvGRIpdkRA=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "1.0.2",
-        "lodash.assign": "3.2.0"
-      }
-    },
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
@@ -7480,15 +6676,6 @@
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
-      }
-    },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
       }
     },
     "performance-now": {
@@ -7642,12 +6829,6 @@
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1"
       }
-    },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -7822,15 +7003,6 @@
         "util.promisify": "1.0.0"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.5.0"
-      }
-    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -7983,18 +7155,6 @@
         "uuid": "3.2.1"
       }
     },
-    "request-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.1",
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.3"
-      }
-    },
     "request-promise-core": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
@@ -8025,12 +7185,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
-    },
-    "require-relative": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
       "dev": true
     },
     "require-uncached": {
@@ -8085,18 +7239,6 @@
         "signal-exit": "3.0.2"
       }
     },
-    "retry": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
-      "dev": true
-    },
-    "rewire": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.2.tgz",
-      "integrity": "sha1-ZCfee3/u+n02QBUH62SlOFvFjcc=",
-      "dev": true
-    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -8125,21 +7267,6 @@
         "is-promise": "2.1.0"
       }
     },
-    "run-auto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/run-auto/-/run-auto-2.0.0.tgz",
-      "integrity": "sha1-X0NT9Yrb1rdJJkibTyWeHa1qeNY=",
-      "dev": true,
-      "requires": {
-        "dezalgo": "1.0.3"
-      }
-    },
-    "run-series": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
-      "integrity": "sha1-iac93F51ye+KtjIMChYA1qQRebk=",
-      "dev": true
-    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -8159,12 +7286,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
-    },
-    "samsam": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
     "sane": {
@@ -8196,46 +7317,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
-    },
-    "semantic-release": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-6.3.6.tgz",
-      "integrity": "sha1-Yp0K7JCziilXpXpKnuEhSvUZKMc=",
-      "dev": true,
-      "requires": {
-        "@semantic-release/commit-analyzer": "2.0.0",
-        "@semantic-release/condition-travis": "5.0.2",
-        "@semantic-release/error": "1.0.0",
-        "@semantic-release/last-release-npm": "1.2.1",
-        "@semantic-release/release-notes-generator": "2.0.0",
-        "git-head": "1.14.0",
-        "github": "8.2.1",
-        "lodash": "4.17.5",
-        "nerf-dart": "1.0.0",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npmconf": "2.1.2",
-        "npmlog": "4.1.2",
-        "parse-github-repo-url": "1.4.1",
-        "require-relative": "0.8.7",
-        "run-auto": "2.0.0",
-        "run-series": "1.1.4",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "npmlog": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-          "dev": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        }
-      }
     },
     "semver": {
       "version": "5.5.0",
@@ -8277,17 +7358,6 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
-      }
-    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -8299,24 +7369,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
-    },
-    "simple-git": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.48.0.tgz",
-      "integrity": "sha1-YhmzpupdMOOXIQ9F8moc1OxVt5k=",
-      "dev": true
-    },
-    "sinon": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true,
-      "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": "0.10.3"
-      }
     },
     "slash": {
       "version": "1.0.0",
@@ -8332,12 +7384,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
       }
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
     },
     "sntp": {
       "version": "2.1.0",
@@ -8393,15 +7439,6 @@
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
@@ -8433,12 +7470,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-      "dev": true
-    },
     "stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -8449,21 +7480,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
-    },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1"
-      }
-    },
-    "stream-consume": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-      "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
     "string-length": {
@@ -8804,189 +7820,6 @@
         }
       }
     },
-    "travis-ci": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/travis-ci/-/travis-ci-2.1.1.tgz",
-      "integrity": "sha1-mGliZa+CeuNXbzGqBth250tLCC4=",
-      "dev": true,
-      "requires": {
-        "github": "0.1.16",
-        "lodash": "1.3.1",
-        "request": "2.74.0",
-        "underscore.string": "2.2.1"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "form-data": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-          "dev": true,
-          "requires": {
-            "async": "2.6.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.17"
-          }
-        },
-        "github": {
-          "version": "0.1.16",
-          "resolved": "https://registry.npmjs.org/github/-/github-0.1.16.tgz",
-          "integrity": "sha1-iV0qhbD+t5gNiawM5PRNyqA/F7U=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.14.1",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "lodash": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
-          "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A=",
-          "dev": true
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.74.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "bl": "1.1.2",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "1.0.1",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.8.2",
-            "qs": "6.2.3",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        }
-      }
-    },
-    "travis-deploy-once": {
-      "version": "1.0.0-node-0.10-support",
-      "resolved": "https://registry.npmjs.org/travis-deploy-once/-/travis-deploy-once-1.0.0-node-0.10-support.tgz",
-      "integrity": "sha1-mOzOfZWy9Lpdze7r9Uud+HcT1eY=",
-      "dev": true,
-      "requires": {
-        "babel-polyfill": "6.26.0",
-        "bluebird": "3.5.1",
-        "request": "2.83.0",
-        "request-promise": "4.2.2",
-        "travis-ci": "2.1.1"
-      }
-    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -9061,22 +7894,10 @@
       "dev": true,
       "optional": true
     },
-    "uid-number": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-      "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4=",
-      "dev": true
-    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-      "dev": true
-    },
-    "underscore.string": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
       "dev": true
     },
     "universalify": {
@@ -9105,23 +7926,6 @@
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
-    },
-    "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -9182,15 +7986,6 @@
       "dev": true,
       "requires": {
         "browser-process-hrtime": "0.1.2"
-      }
-    },
-    "walk": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
-      "integrity": "sha1-MbTbZnjyrgHDnqn7hyWpAx5Vins=",
-      "dev": true,
-      "requires": {
-        "foreachasync": "3.0.0"
       }
     },
     "walker": {
@@ -9313,28 +8108,6 @@
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
-    },
-    "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
-      "dev": true,
-      "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
-          "dev": true
-        }
-      }
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/packages/file-collections/src/node/MeteorFileCollection.js
+++ b/packages/file-collections/src/node/MeteorFileCollection.js
@@ -156,7 +156,7 @@ export default class MeteorFileCollection extends FileCollection {
    * @method _find
    * @param {Object|String} selector A FileRecord ID or MongoDB selector
    * @param {Object} options Options object to be passed through to Meteor's findOne
-   * @returns {Promise<Cursor>} A Promise that resolves with the Meteor find cursor
+   * @returns {Promise<Object[]>} A Promise that resolves with an array of file documents that match the selector
    */
   _find(selector, options) {
     return new Promise((resolve, reject) => {

--- a/packages/file-collections/src/node/MongoFileCollection.js
+++ b/packages/file-collections/src/node/MongoFileCollection.js
@@ -1,0 +1,94 @@
+import FileCollection from "../common/FileCollection";
+
+/**
+ * @class MongoFileCollection
+ * @extends FileCollection
+ *
+ * A type of FileCollection that uses a Mongo Collection as its backing storage
+ */
+export default class MongoFileCollection extends FileCollection {
+  /**
+   * @constructor MongoFileCollection
+   * @param {String} name The name you want to use to refer to the FileCollection
+   * @param {Object} options
+   * @param {Collection} options.collection The collection to use. Call db.collection(name) from the
+   *   Mongo NPM package to get this reference.
+   *
+   * Additional options documented in FileCollection class
+   */
+  constructor(name, options = {}) {
+    const { collection, makeNewStringID, ...opts } = options;
+
+    super(name, opts);
+
+    if (!collection) throw new Error(`MongoFileCollection "${name}": You must pass the "collection" option`);
+    if (typeof makeNewStringID !== "function") throw new Error(`MongoFileCollection "${name}": You must pass a function for the "makeNewStringID" option`);
+
+    this.collection = collection;
+    this.makeNewStringID = makeNewStringID;
+  }
+
+  /**
+   * @method _insert
+   * @param {Object} doc An object to be inserted.
+   * @returns {Promise<Object>} A Promise that resolves with the inserted object.
+   */
+  async _insert(doc) {
+    // Generate string ID to avoid getting a Mongo ObjectID
+    if (!doc._id) doc._id = this.makeNewStringID();
+    await this.collection.insert(doc);
+    return this._findOne(doc._id);
+  }
+
+  /**
+   * @method _update
+   * @param {String} id A FileRecord ID
+   * @param {Object} modifier An object to be used as the update modifier.
+   * @returns {Promise<Object>} A Promise that resolves with the updated object.
+   */
+  async _update(id, modifier, options) {
+    await this.collection.update({ _id: id }, modifier, options);
+    return this._findOne(id);
+  }
+
+  /**
+   * @method _remove
+   * @param {String} id A FileRecord ID
+   * @param {Object} [options]
+   * @returns {Promise<Number>} A Promise that resolves with 1 if success.
+   */
+  async _remove(id, options) {
+    await this.collection.remove({ _id: id }, options);
+    return 1;
+  }
+
+  /**
+   * @method _findOne
+   * @param {String|Object} selector A FileRecord ID or MongoDB Selector
+   * @param {Object} options Options object to be passed through to Mongo's findOne
+   * @returns {Promise<Object|undefined>} A Promise that resolves with the document or undefined
+   */
+  async _findOne(selector, options) {
+    const finalSelector = typeof selector === "string" ? { _id: selector } : selector;
+    return this.collection.findOne(finalSelector, options);
+  }
+
+  /**
+   * @method _find
+   * @param {Object|String} selector A FileRecord ID or MongoDB selector
+   * @param {Object} options Options object to be passed through to Mongo's findOne
+   * @returns {Promise<Object[]>} A Promise that resolves with a potentially-empty array of documents
+   */
+  async _find(selector, options) {
+    const finalSelector = typeof selector === "string" ? { _id: selector } : selector;
+    return this.collection.find(finalSelector || {}, options || {}).toArray();
+  }
+
+  _findOneLocal() {
+    throw new Error("MongoFileCollection does not support findOneLocal in Node code. Use findOne");
+  }
+
+  _findLocal() {
+    throw new Error("MongoFileCollection does not support findLocal in Node code. Use find");
+  }
+}

--- a/packages/file-collections/src/node/MongoFileCollection.test.js
+++ b/packages/file-collections/src/node/MongoFileCollection.test.js
@@ -1,0 +1,19 @@
+import MongoFileCollection from "./MongoFileCollection";
+
+const collection = {};
+
+const stores = [
+  { on() {} }
+];
+
+test("throws if missing collection option", () => {
+  expect(() => {
+    new MongoFileCollection("foo", { stores }); // eslint-disable-line no-new
+  }).toThrow('You must pass the "collection" option');
+});
+
+test("throws if missing makeNewStringID option", () => {
+  expect(() => {
+    new MongoFileCollection("foo", { collection, stores }); // eslint-disable-line no-new
+  }).toThrow('You must pass a function for the "makeNewStringID" option');
+});

--- a/packages/file-collections/src/node/index.js
+++ b/packages/file-collections/src/node/index.js
@@ -4,4 +4,5 @@ export { default as FileRecord } from "../common/FileRecord";
 export { default as RemoteUrlWorker } from "./RemoteUrlWorker";
 export { default as TempFileStoreWorker } from "./TempFileStoreWorker";
 export { default as MeteorFileCollection } from "./MeteorFileCollection";
+export { default as MongoFileCollection } from "./MongoFileCollection";
 export { default as TempFileStore } from "./TempFileStore";


### PR DESCRIPTION
Resolves #8 

Added `MongoFileCollection` class and documentation changes for it. This class works in Node code as a drop-in replacement for `MeteorFileCollection`, except that it cannot be provided to a `TempFileStoreWorker` or `RemoteUrlWorker` because those currently use Meteor observe. We can eventually make polling versions, or implement observations outside of Meteor, but that is outside the scope of this.