### PR TITLE
fix(file-collection): patch hoek and tunnel agent

### DIFF
--- a/packages/file-collections/.snyk
+++ b/packages/file-collections/.snyk
@@ -1,0 +1,17 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.11.0
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  'npm:hoek:20180212':
+    - tus-node-server > @google-cloud/storage > gcs-resumable-upload > google-auto-auth > gcp-metadata > retry-request > request > hawk > boom > hoek:
+        patched: '2018-07-16T21:39:24.829Z'
+    - tus-node-server > @google-cloud/storage > gcs-resumable-upload > google-auto-auth > gcp-metadata > retry-request > request > hawk > sntp > hoek:
+        patched: '2018-07-16T21:39:24.829Z'
+    - tus-node-server > @google-cloud/storage > gcs-resumable-upload > google-auto-auth > gcp-metadata > retry-request > request > hawk > cryptiles > boom > hoek:
+        patched: '2018-07-16T21:39:24.829Z'
+    - tus-node-server > @google-cloud/storage > gcs-resumable-upload > google-auto-auth > gcp-metadata > retry-request > request > hawk > hoek:
+        patched: '2018-07-16T21:39:24.829Z'
+  'npm:tunnel-agent:20170305':
+    - tus-node-server > @google-cloud/storage > gcs-resumable-upload > google-auto-auth > gcp-metadata > retry-request > request > tunnel-agent:
+        patched: '2018-07-16T21:39:24.829Z'

--- a/packages/file-collections/package-lock.json
+++ b/packages/file-collections/package-lock.json
@@ -135,51 +135,6 @@
         }
       }
     },
-    "@google-cloud/bigquery": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-0.9.6.tgz",
-      "integrity": "sha1-vqxtSGxF+AEKSAQ43klFJS/Ezq4=",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "arrify": "1.0.1",
-        "duplexify": "3.5.3",
-        "extend": "3.0.1",
-        "is": "3.2.1",
-        "stream-events": "1.0.2",
-        "string-format-obj": "1.1.1"
-      }
-    },
-    "@google-cloud/bigtable": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/bigtable/-/bigtable-0.10.2.tgz",
-      "integrity": "sha1-NOZ5sZZH3uZ0Tj4e/lR71uvY2wE=",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "@google-cloud/common-grpc": "0.4.3",
-        "arrify": "1.0.1",
-        "concat-stream": "1.6.0",
-        "create-error-class": "3.0.2",
-        "dot-prop": "3.0.0",
-        "extend": "3.0.1",
-        "is": "3.2.1",
-        "lodash.flatten": "4.4.0",
-        "node-int64": "0.4.0",
-        "prop-assign": "1.0.0",
-        "pumpify": "1.4.0",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "dot-prop": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-          "requires": {
-            "is-obj": "1.0.1"
-          }
-        }
-      }
-    },
     "@google-cloud/common": {
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.13.6.tgz",
@@ -187,2159 +142,59 @@
       "requires": {
         "array-uniq": "1.0.3",
         "arrify": "1.0.1",
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "create-error-class": "3.0.2",
-        "duplexify": "3.5.3",
+        "duplexify": "3.6.0",
         "ent": "2.2.0",
         "extend": "3.0.1",
         "google-auto-auth": "0.7.2",
         "is": "3.2.1",
-        "log-driver": "1.2.6",
+        "log-driver": "1.2.7",
         "methmeth": "1.1.0",
         "modelo": "4.2.3",
-        "request": "2.83.0",
-        "retry-request": "3.3.1",
+        "request": "2.87.0",
+        "retry-request": "3.3.2",
         "split-array-stream": "1.0.3",
-        "stream-events": "1.0.2",
+        "stream-events": "1.0.4",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       },
       "dependencies": {
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
         "google-auto-auth": {
           "version": "0.7.2",
           "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
           "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
           "requires": {
-            "async": "2.6.0",
+            "async": "2.6.1",
             "gcp-metadata": "0.3.1",
             "google-auth-library": "0.10.0",
-            "request": "2.83.0"
-          }
-        }
-      }
-    },
-    "@google-cloud/common-grpc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common-grpc/-/common-grpc-0.4.3.tgz",
-      "integrity": "sha512-A3nErp1qV8iCWPYQniBhot7Gx+kZHTAuRzOQyoPpfbv9pLmsvZgTWzVUg1/R1ncrirQElHUDhIFXPV+kr+UJAA==",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "dot-prop": "2.4.0",
-        "duplexify": "3.5.3",
-        "extend": "3.0.1",
-        "grpc": "1.9.0",
-        "is": "3.2.1",
-        "modelo": "4.2.3",
-        "retry-request": "3.3.1",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "dot-prop": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.4.0.tgz",
-          "integrity": "sha1-hI4o9/HVB0DGdHqzywdnBGK2+Jw=",
-          "requires": {
-            "is-obj": "1.0.1"
-          }
-        }
-      }
-    },
-    "@google-cloud/compute": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/compute/-/compute-0.8.0.tgz",
-      "integrity": "sha1-CiExGcAbja55/uMgdRYfSEZt5Ig=",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "arrify": "1.0.1",
-        "async": "2.6.0",
-        "create-error-class": "3.0.2",
-        "extend": "3.0.1",
-        "gce-images": "0.3.3",
-        "is": "3.2.1",
-        "string-format-obj": "1.1.1"
-      }
-    },
-    "@google-cloud/datastore": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/datastore/-/datastore-1.3.3.tgz",
-      "integrity": "sha512-TMJmhW5tls6jGRJROp/57PG2b1sZENsd5D3mHNUtFFegK7voPK9HbDjR1OhbYEg9X0TerkStJYseoCD7BOQryw==",
-      "requires": {
-        "@google-cloud/common": "0.14.0",
-        "arrify": "1.0.1",
-        "concat-stream": "1.6.0",
-        "create-error-class": "3.0.2",
-        "extend": "3.0.1",
-        "google-auto-auth": "0.9.3",
-        "google-gax": "0.14.5",
-        "google-proto-files": "0.13.1",
-        "is": "3.2.1",
-        "lodash.flatten": "4.4.0",
-        "lodash.merge": "4.6.1",
-        "prop-assign": "1.0.0",
-        "propprop": "0.3.1",
-        "safe-buffer": "5.1.1",
-        "split-array-stream": "1.0.3",
-        "stream-events": "1.0.2",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "@google-cloud/common": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.14.0.tgz",
-          "integrity": "sha1-xWA4KXJH6nKnUNUUVegBcQl2rEM=",
-          "requires": {
-            "array-uniq": "1.0.3",
-            "arrify": "1.0.1",
-            "concat-stream": "1.6.0",
-            "create-error-class": "3.0.2",
-            "duplexify": "3.5.3",
-            "ent": "2.2.0",
-            "extend": "3.0.1",
-            "google-auto-auth": "0.7.2",
-            "is": "3.2.1",
-            "log-driver": "1.2.6",
-            "methmeth": "1.1.0",
-            "modelo": "4.2.3",
-            "request": "2.83.0",
-            "retry-request": "3.3.1",
-            "split-array-stream": "1.0.3",
-            "stream-events": "1.0.2",
-            "string-format-obj": "1.1.1",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "google-auto-auth": {
-              "version": "0.7.2",
-              "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
-              "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
-              "requires": {
-                "async": "2.6.0",
-                "gcp-metadata": "0.3.1",
-                "google-auth-library": "0.10.0",
-                "request": "2.83.0"
-              }
-            }
-          }
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.3.tgz",
-          "integrity": "sha512-TbOZZs0WJOolrRmdQLK5qmWdOJQFG1oPnxcIBbAwL7XCWcv3XgZ9gHJ6W4byrdEZT8TahNFgMfkHd73mqxM9dw==",
-          "requires": {
-            "async": "2.6.0",
-            "gcp-metadata": "0.4.1",
-            "google-auth-library": "0.12.0",
-            "request": "2.83.0"
-          },
-          "dependencies": {
-            "gcp-metadata": {
-              "version": "0.4.1",
-              "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.4.1.tgz",
-              "integrity": "sha512-yFE7v+NyoMiTOi2L6r8q87eVbiZCKooJNPKXTHhBStga8pwwgWofK9iHl00qd0XevZxcpk7ORaEL/ALuTvlaGQ==",
-              "requires": {
-                "extend": "3.0.1",
-                "retry-request": "3.3.1"
-              }
-            },
-            "google-auth-library": {
-              "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
-              "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
-              "requires": {
-                "gtoken": "1.2.3",
-                "jws": "3.1.4",
-                "lodash.isstring": "4.0.1",
-                "lodash.merge": "4.6.1",
-                "request": "2.83.0"
-              }
-            }
-          }
-        }
-      }
-    },
-    "@google-cloud/dlp": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/dlp/-/dlp-0.1.3.tgz",
-      "integrity": "sha1-xwbOK6Bj76xyAppRsfShdfknrGI=",
-      "requires": {
-        "extend": "3.0.1",
-        "google-gax": "0.13.5",
-        "google-proto-files": "0.12.1"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.5.4.tgz",
-          "integrity": "sha1-HYbHko1jPnWpwasDSlJ+/M5KQLE=",
-          "requires": {
-            "async": "2.6.0",
-            "google-auth-library": "0.10.0",
-            "object-assign": "3.0.0",
-            "request": "2.83.0"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-            }
-          }
-        },
-        "google-gax": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.13.5.tgz",
-          "integrity": "sha1-OkjMUrfhZPcxk4836t0rc/fEk9c=",
-          "requires": {
-            "extend": "3.0.1",
-            "globby": "6.1.0",
-            "google-auto-auth": "0.5.4",
-            "google-proto-files": "0.13.1",
-            "grpc": "1.9.0",
-            "is-stream-ended": "0.1.3",
-            "lodash": "4.17.5",
-            "process-nextick-args": "1.0.7",
-            "protobufjs": "6.8.4",
-            "readable-stream": "2.3.3",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "google-proto-files": {
-              "version": "0.13.1",
-              "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.13.1.tgz",
-              "integrity": "sha512-CivI3rZ85dMPTCAyxq6lq9s7vDkeWEIFxweopC1vEjjRmFMJwOX/MOmFZ90a0BGal/Dsb63vq7Ael9ryeokz0g=="
-            }
-          }
-        },
-        "google-proto-files": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.12.1.tgz",
-          "integrity": "sha512-d+BiTMpYP4/pN+Kgi0lWE+2/GaVN4jy8LCabjo2Wd16Ykm5oRO5bI40bo8u2U4rN/GpZkMyfxZAjWVPRjGe3nQ=="
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "protobufjs": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
-          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.9.1",
-            "long": "3.2.0"
-          }
-        }
-      }
-    },
-    "@google-cloud/dns": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/dns/-/dns-0.6.2.tgz",
-      "integrity": "sha1-CGgU407lw+DfF3fcEP3I3NJoob8=",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "arrify": "1.0.1",
-        "dns-zonefile": "0.1.18",
-        "extend": "3.0.1",
-        "is": "3.2.1",
-        "methmeth": "1.1.0",
-        "string-format-obj": "1.1.1"
-      }
-    },
-    "@google-cloud/firestore": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-0.8.2.tgz",
-      "integrity": "sha512-Z9hoiZIIn1MN7lUZE0pStvkrTdzJnSyFyxDJ4VojkzF/lL4EAUr9USyWXol6HZYcERPjXIasHSXXTYwuXx8tmA==",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "@google-cloud/common-grpc": "0.4.3",
-        "bun": "0.0.12",
-        "extend": "3.0.1",
-        "functional-red-black-tree": "1.0.1",
-        "google-gax": "0.14.5",
-        "grpc": "1.9.0",
-        "is": "3.2.1",
-        "through2": "2.0.3"
-      }
-    },
-    "@google-cloud/language": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/language/-/language-0.12.1.tgz",
-      "integrity": "sha1-P57EQeuou+gDBwa5oJ4BFMFw/uE=",
-      "requires": {
-        "extend": "3.0.1",
-        "google-gax": "0.13.5"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.5.4.tgz",
-          "integrity": "sha1-HYbHko1jPnWpwasDSlJ+/M5KQLE=",
-          "requires": {
-            "async": "2.6.0",
-            "google-auth-library": "0.10.0",
-            "object-assign": "3.0.0",
-            "request": "2.83.0"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-            }
-          }
-        },
-        "google-gax": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.13.5.tgz",
-          "integrity": "sha1-OkjMUrfhZPcxk4836t0rc/fEk9c=",
-          "requires": {
-            "extend": "3.0.1",
-            "globby": "6.1.0",
-            "google-auto-auth": "0.5.4",
-            "google-proto-files": "0.13.1",
-            "grpc": "1.9.0",
-            "is-stream-ended": "0.1.3",
-            "lodash": "4.17.5",
-            "process-nextick-args": "1.0.7",
-            "protobufjs": "6.8.4",
-            "readable-stream": "2.3.3",
-            "through2": "2.0.3"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "protobufjs": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
-          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.9.1",
-            "long": "3.2.0"
-          }
-        }
-      }
-    },
-    "@google-cloud/logging": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-1.1.2.tgz",
-      "integrity": "sha512-TXpUcNZj8J2TRtZU+lKY3c0nyaW8AsD5yJUiszmwcTiXHtsBqK9vDVJgMhQTBO9xx3wMPfJcDOTkHgcMopBfUw==",
-      "requires": {
-        "@google-cloud/common": "0.15.1",
-        "@google-cloud/common-grpc": "0.5.4",
-        "arrify": "1.0.1",
-        "eventid": "0.1.2",
-        "extend": "3.0.1",
-        "gcp-metadata": "0.4.1",
-        "google-auto-auth": "0.9.3",
-        "google-gax": "0.14.5",
-        "google-proto-files": "0.14.2",
-        "is": "3.2.1",
-        "lodash.merge": "4.6.1",
-        "protobufjs": "6.8.4",
-        "pumpify": "1.4.0",
-        "snakecase-keys": "1.1.0",
-        "stream-events": "1.0.2",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "@google-cloud/common": {
-          "version": "0.15.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.15.1.tgz",
-          "integrity": "sha512-cnVtHLvyiSQvb1RzXWDp7PA1sA8Jmc47+wp/xwHwdGOlQZfKog5iluZ0C/LB8iklFXpcTwlNMorqLuZ/qH0DDA==",
-          "requires": {
-            "array-uniq": "1.0.3",
-            "arrify": "1.0.1",
-            "concat-stream": "1.6.0",
-            "create-error-class": "3.0.2",
-            "duplexify": "3.5.3",
-            "ent": "2.2.0",
-            "extend": "3.0.1",
-            "google-auto-auth": "0.8.2",
-            "is": "3.2.1",
-            "log-driver": "1.2.6",
-            "methmeth": "1.1.0",
-            "modelo": "4.2.3",
-            "request": "2.83.0",
-            "retry-request": "3.3.1",
-            "split-array-stream": "1.0.3",
-            "stream-events": "1.0.2",
-            "string-format-obj": "1.1.1",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "gcp-metadata": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.3.1.tgz",
-              "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
-              "requires": {
-                "extend": "3.0.1",
-                "retry-request": "3.3.1"
-              }
-            },
-            "google-auto-auth": {
-              "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.8.2.tgz",
-              "integrity": "sha512-W91J1paFbyG45gpDWdTu9tKDxbiTDWYkOAxytNVF4oHVVgTCBV/8+lWdjj/6ldjN3eb+sEd9PKJBjm0kmCxvcw==",
-              "requires": {
-                "async": "2.6.0",
-                "gcp-metadata": "0.3.1",
-                "google-auth-library": "0.12.0",
-                "request": "2.83.0"
-              }
-            }
-          }
-        },
-        "@google-cloud/common-grpc": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common-grpc/-/common-grpc-0.5.4.tgz",
-          "integrity": "sha512-/2dZNHCs7ZBScsTlf8+VVscJXX32jRfVZaO1vLfu291SsAe0Vuxpoc9JyVQARe+Z/MPVnahY9M6uuMmf7QUyAg==",
-          "requires": {
-            "@google-cloud/common": "0.15.1",
-            "dot-prop": "4.2.0",
-            "duplexify": "3.5.3",
-            "extend": "3.0.1",
-            "grpc": "1.7.3",
-            "is": "3.2.1",
-            "modelo": "4.2.3",
-            "retry-request": "3.3.1",
-            "through2": "2.0.3"
-          }
-        },
-        "gcp-metadata": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.4.1.tgz",
-          "integrity": "sha512-yFE7v+NyoMiTOi2L6r8q87eVbiZCKooJNPKXTHhBStga8pwwgWofK9iHl00qd0XevZxcpk7ORaEL/ALuTvlaGQ==",
-          "requires": {
-            "extend": "3.0.1",
-            "retry-request": "3.3.1"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.3.tgz",
-          "integrity": "sha512-TbOZZs0WJOolrRmdQLK5qmWdOJQFG1oPnxcIBbAwL7XCWcv3XgZ9gHJ6W4byrdEZT8TahNFgMfkHd73mqxM9dw==",
-          "requires": {
-            "async": "2.6.0",
-            "gcp-metadata": "0.4.1",
-            "google-auth-library": "0.12.0",
-            "request": "2.83.0"
-          }
-        },
-        "google-proto-files": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.14.2.tgz",
-          "integrity": "sha512-wwm2TIlfTgAjDbjrxAb3akznO7vBM0PRLS6Xf2QfR3L7b0p+szD3iwOW0wMSFl3B0UbLv27hUVk+clePqCVmXA==",
-          "requires": {
-            "globby": "7.1.1",
-            "power-assert": "1.4.4",
-            "prettier": "1.10.2",
-            "protobufjs": "6.8.4"
-          }
-        },
-        "grpc": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.3.tgz",
-          "integrity": "sha512-7zXQJlDXMr/ZaDqdaIchgclViyoWo8GQxZSmFUAxR8GwSr28b6/BTgF221WG+2W693jpp74XJ/+I9DcPXsgt9Q==",
-          "requires": {
-            "arguejs": "0.2.3",
-            "lodash": "4.17.5",
-            "nan": "2.8.0",
-            "node-pre-gyp": "0.6.39",
-            "protobufjs": "5.0.2"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.9",
-              "bundled": true
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.3"
-              }
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            },
-            "boom": {
-              "version": "2.10.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "bundled": true,
-              "requires": {
-                "boom": "2.10.1"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "detect-libc": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
-              }
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.1",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "bundled": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "bundled": true,
-              "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "bundled": true
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "node-pre-gyp": {
-              "version": "0.6.39",
-              "bundled": true,
-              "requires": {
-                "detect-libc": "1.0.2",
-                "hawk": "3.1.3",
-                "mkdirp": "0.5.1",
-                "nopt": "4.0.1",
-                "npmlog": "4.1.2",
-                "rc": "1.2.2",
-                "request": "2.81.0",
-                "rimraf": "2.6.2",
-                "semver": "5.4.1",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.1"
-              },
-              "dependencies": {
-                "nopt": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "abbrev": "1.0.9",
-                    "osenv": "0.1.4"
-                  }
-                }
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "protobufjs": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
-              "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
-              "requires": {
-                "ascli": "1.0.1",
-                "bytebuffer": "5.0.1",
-                "glob": "7.1.1",
-                "yargs": "3.32.0"
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true
-            },
-            "rc": {
-              "version": "1.2.2",
-              "bundled": true,
-              "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.2",
-              "bundled": true,
-              "requires": {
-                "glob": "7.1.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "semver": {
-              "version": "5.4.1",
-              "bundled": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "bundled": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              }
-            },
-            "tar-pack": {
-              "version": "3.4.1",
-              "bundled": true,
-              "requires": {
-                "debug": "2.6.8",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.3.3",
-                "rimraf": "2.6.2",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "bundled": true,
-              "requires": {
-                "string-width": "1.0.2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "protobufjs": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
-          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.9.1",
-            "long": "3.2.0"
-          }
-        }
-      }
-    },
-    "@google-cloud/monitoring": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/monitoring/-/monitoring-0.3.0.tgz",
-      "integrity": "sha1-trJajKeBBT2b55grLpry2h7+2R8=",
-      "requires": {
-        "extend": "3.0.1",
-        "google-gax": "0.13.5",
-        "google-proto-files": "0.12.1"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.5.4.tgz",
-          "integrity": "sha1-HYbHko1jPnWpwasDSlJ+/M5KQLE=",
-          "requires": {
-            "async": "2.6.0",
-            "google-auth-library": "0.10.0",
-            "object-assign": "3.0.0",
-            "request": "2.83.0"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-            }
-          }
-        },
-        "google-gax": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.13.5.tgz",
-          "integrity": "sha1-OkjMUrfhZPcxk4836t0rc/fEk9c=",
-          "requires": {
-            "extend": "3.0.1",
-            "globby": "6.1.0",
-            "google-auto-auth": "0.5.4",
-            "google-proto-files": "0.13.1",
-            "grpc": "1.9.0",
-            "is-stream-ended": "0.1.3",
-            "lodash": "4.17.5",
-            "process-nextick-args": "1.0.7",
-            "protobufjs": "6.8.4",
-            "readable-stream": "2.3.3",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "google-proto-files": {
-              "version": "0.13.1",
-              "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.13.1.tgz",
-              "integrity": "sha512-CivI3rZ85dMPTCAyxq6lq9s7vDkeWEIFxweopC1vEjjRmFMJwOX/MOmFZ90a0BGal/Dsb63vq7Ael9ryeokz0g=="
-            }
-          }
-        },
-        "google-proto-files": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.12.1.tgz",
-          "integrity": "sha512-d+BiTMpYP4/pN+Kgi0lWE+2/GaVN4jy8LCabjo2Wd16Ykm5oRO5bI40bo8u2U4rN/GpZkMyfxZAjWVPRjGe3nQ=="
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "protobufjs": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
-          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.9.1",
-            "long": "3.2.0"
-          }
-        }
-      }
-    },
-    "@google-cloud/prediction": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/prediction/-/prediction-0.6.2.tgz",
-      "integrity": "sha1-AGJTvxxENTDhLH1A40KP/gxHZcI=",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "JSONStream": "1.3.2",
-        "arrify": "1.0.1",
-        "extend": "3.0.1",
-        "is": "3.2.1",
-        "pumpify": "1.4.0",
-        "stream-events": "1.0.2",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
-      }
-    },
-    "@google-cloud/pubsub": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-0.14.8.tgz",
-      "integrity": "sha512-SarceyFmvq6xnn8pkirdjpP25O3GRFMzr2oO3OGEnA7K8l0ObPHjU6R+DJbOS5UVpP4Vi2vHj3w8XTDM18dicA==",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "@google-cloud/common-grpc": "0.4.3",
-        "arrify": "1.0.1",
-        "async-each": "1.0.1",
-        "extend": "3.0.1",
-        "google-auto-auth": "0.7.2",
-        "google-gax": "0.13.5",
-        "google-proto-files": "0.13.1",
-        "is": "3.2.1",
-        "lodash.snakecase": "4.1.1",
-        "uuid": "3.2.1"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
-          "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
-          "requires": {
-            "async": "2.6.0",
-            "gcp-metadata": "0.3.1",
-            "google-auth-library": "0.10.0",
-            "request": "2.83.0"
-          }
-        },
-        "google-gax": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.13.5.tgz",
-          "integrity": "sha1-OkjMUrfhZPcxk4836t0rc/fEk9c=",
-          "requires": {
-            "extend": "3.0.1",
-            "globby": "6.1.0",
-            "google-auto-auth": "0.5.4",
-            "google-proto-files": "0.13.1",
-            "grpc": "1.9.0",
-            "is-stream-ended": "0.1.3",
-            "lodash": "4.17.5",
-            "process-nextick-args": "1.0.7",
-            "protobufjs": "6.8.4",
-            "readable-stream": "2.3.3",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "google-auto-auth": {
-              "version": "0.5.4",
-              "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.5.4.tgz",
-              "integrity": "sha1-HYbHko1jPnWpwasDSlJ+/M5KQLE=",
-              "requires": {
-                "async": "2.6.0",
-                "google-auth-library": "0.10.0",
-                "object-assign": "3.0.0",
-                "request": "2.83.0"
-              }
-            },
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-            }
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "protobufjs": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
-          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.9.1",
-            "long": "3.2.0"
-          }
-        }
-      }
-    },
-    "@google-cloud/resource": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/resource/-/resource-0.7.3.tgz",
-      "integrity": "sha1-sYovOJ30XtSGnOQNtVQop4QW+q0=",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "extend": "3.0.1",
-        "is": "3.2.1"
-      }
-    },
-    "@google-cloud/spanner": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/spanner/-/spanner-0.7.1.tgz",
-      "integrity": "sha1-yFmgcuwJnZXmxtyHb7tOGcq8o9k=",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "@google-cloud/common-grpc": "0.4.3",
-        "array-uniq": "1.0.3",
-        "arrify": "1.0.1",
-        "checkpoint-stream": "0.1.1",
-        "events-intercept": "2.0.0",
-        "extend": "3.0.1",
-        "generic-pool": "3.4.1",
-        "google-gax": "0.13.5",
-        "google-proto-files": "0.12.1",
-        "is": "3.2.1",
-        "lodash.chunk": "4.2.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.snakecase": "4.1.1",
-        "merge-stream": "1.0.1",
-        "methmeth": "1.1.0",
-        "split-array-stream": "1.0.3",
-        "stream-events": "1.0.2",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.5.4.tgz",
-          "integrity": "sha1-HYbHko1jPnWpwasDSlJ+/M5KQLE=",
-          "requires": {
-            "async": "2.6.0",
-            "google-auth-library": "0.10.0",
-            "object-assign": "3.0.0",
-            "request": "2.83.0"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-            }
-          }
-        },
-        "google-gax": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.13.5.tgz",
-          "integrity": "sha1-OkjMUrfhZPcxk4836t0rc/fEk9c=",
-          "requires": {
-            "extend": "3.0.1",
-            "globby": "6.1.0",
-            "google-auto-auth": "0.5.4",
-            "google-proto-files": "0.13.1",
-            "grpc": "1.9.0",
-            "is-stream-ended": "0.1.3",
-            "lodash": "4.17.5",
-            "process-nextick-args": "1.0.7",
-            "protobufjs": "6.8.4",
-            "readable-stream": "2.3.3",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "google-proto-files": {
-              "version": "0.13.1",
-              "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.13.1.tgz",
-              "integrity": "sha512-CivI3rZ85dMPTCAyxq6lq9s7vDkeWEIFxweopC1vEjjRmFMJwOX/MOmFZ90a0BGal/Dsb63vq7Ael9ryeokz0g=="
-            }
-          }
-        },
-        "google-proto-files": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.12.1.tgz",
-          "integrity": "sha512-d+BiTMpYP4/pN+Kgi0lWE+2/GaVN4jy8LCabjo2Wd16Ykm5oRO5bI40bo8u2U4rN/GpZkMyfxZAjWVPRjGe3nQ=="
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "protobufjs": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
-          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.9.1",
-            "long": "3.2.0"
-          }
-        }
-      }
-    },
-    "@google-cloud/speech": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/speech/-/speech-0.10.3.tgz",
-      "integrity": "sha1-ovMmiSkCW2C1yL0yRkNPimGHgHs=",
-      "requires": {
-        "extend": "3.0.1",
-        "google-gax": "0.13.5",
-        "google-proto-files": "0.13.1",
-        "pumpify": "1.4.0",
-        "stream-events": "1.0.2",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.5.4.tgz",
-          "integrity": "sha1-HYbHko1jPnWpwasDSlJ+/M5KQLE=",
-          "requires": {
-            "async": "2.6.0",
-            "google-auth-library": "0.10.0",
-            "object-assign": "3.0.0",
-            "request": "2.83.0"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-            }
-          }
-        },
-        "google-gax": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.13.5.tgz",
-          "integrity": "sha1-OkjMUrfhZPcxk4836t0rc/fEk9c=",
-          "requires": {
-            "extend": "3.0.1",
-            "globby": "6.1.0",
-            "google-auto-auth": "0.5.4",
-            "google-proto-files": "0.13.1",
-            "grpc": "1.9.0",
-            "is-stream-ended": "0.1.3",
-            "lodash": "4.17.5",
-            "process-nextick-args": "1.0.7",
-            "protobufjs": "6.8.4",
-            "readable-stream": "2.3.3",
-            "through2": "2.0.3"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "protobufjs": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
-          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.9.1",
-            "long": "3.2.0"
+            "request": "2.87.0"
           }
         }
       }
     },
     "@google-cloud/storage": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.5.2.tgz",
-      "integrity": "sha512-E97x2oZr9w0N26H0LtyjR3XLFSLYXH5D8y8HwEZRWQnNVF9sO+x16MEhdHFdFclgdx687eGeCYbDVKpP+dKb6w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.1.1.tgz",
+      "integrity": "sha1-ZZC1zm53lVbJzHBDvWRJ1rwHgd4=",
       "requires": {
-        "@google-cloud/common": "0.15.1",
+        "@google-cloud/common": "0.13.6",
         "arrify": "1.0.1",
-        "async": "2.6.0",
-        "concat-stream": "1.6.0",
+        "async": "2.6.1",
+        "concat-stream": "1.6.2",
         "create-error-class": "3.0.2",
-        "duplexify": "3.5.3",
+        "duplexify": "3.6.0",
         "extend": "3.0.1",
-        "gcs-resumable-upload": "0.8.2",
+        "gcs-resumable-upload": "0.7.7",
         "hash-stream-validation": "0.2.1",
         "is": "3.2.1",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "once": "1.4.0",
-        "pumpify": "1.4.0",
-        "request": "2.83.0",
-        "safe-buffer": "5.1.1",
-        "snakeize": "0.1.0",
-        "stream-events": "1.0.2",
+        "pumpify": "1.5.1",
+        "stream-events": "1.0.4",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
-      },
-      "dependencies": {
-        "@google-cloud/common": {
-          "version": "0.15.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.15.1.tgz",
-          "integrity": "sha512-cnVtHLvyiSQvb1RzXWDp7PA1sA8Jmc47+wp/xwHwdGOlQZfKog5iluZ0C/LB8iklFXpcTwlNMorqLuZ/qH0DDA==",
-          "requires": {
-            "array-uniq": "1.0.3",
-            "arrify": "1.0.1",
-            "concat-stream": "1.6.0",
-            "create-error-class": "3.0.2",
-            "duplexify": "3.5.3",
-            "ent": "2.2.0",
-            "extend": "3.0.1",
-            "google-auto-auth": "0.8.2",
-            "is": "3.2.1",
-            "log-driver": "1.2.6",
-            "methmeth": "1.1.0",
-            "modelo": "4.2.3",
-            "request": "2.83.0",
-            "retry-request": "3.3.1",
-            "split-array-stream": "1.0.3",
-            "stream-events": "1.0.2",
-            "string-format-obj": "1.1.1",
-            "through2": "2.0.3"
-          }
-        }
       }
-    },
-    "@google-cloud/translate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/translate/-/translate-1.1.0.tgz",
-      "integrity": "sha512-UzllqCIb5aJys7qzX2pJ2eTrgJN8nd9TQurjPPBPoiIzuHojY5bTIdNUEEo01o1u9bQ/2trlaKEuwYXhoGXIww==",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "arrify": "1.0.1",
-        "extend": "3.0.1",
-        "is": "3.2.1",
-        "is-html": "1.1.0",
-        "propprop": "0.3.1"
-      }
-    },
-    "@google-cloud/video-intelligence": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/video-intelligence/-/video-intelligence-0.3.2.tgz",
-      "integrity": "sha1-46Q7CN7CdE6WVX+lqt2l7qFs+KY=",
-      "requires": {
-        "extend": "3.0.1",
-        "google-gax": "0.14.5",
-        "protobufjs": "6.8.4"
-      },
-      "dependencies": {
-        "protobufjs": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
-          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.9.1",
-            "long": "3.2.0"
-          }
-        }
-      }
-    },
-    "@google-cloud/vision": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/vision/-/vision-0.12.0.tgz",
-      "integrity": "sha1-/6sKGODm6oQebE6BJzzUaAn98D4=",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "async": "2.6.0",
-        "extend": "3.0.1",
-        "google-gax": "0.13.5",
-        "google-proto-files": "0.12.1",
-        "is": "3.2.1"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.5.4.tgz",
-          "integrity": "sha1-HYbHko1jPnWpwasDSlJ+/M5KQLE=",
-          "requires": {
-            "async": "2.6.0",
-            "google-auth-library": "0.10.0",
-            "object-assign": "3.0.0",
-            "request": "2.83.0"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-            }
-          }
-        },
-        "google-gax": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.13.5.tgz",
-          "integrity": "sha1-OkjMUrfhZPcxk4836t0rc/fEk9c=",
-          "requires": {
-            "extend": "3.0.1",
-            "globby": "6.1.0",
-            "google-auto-auth": "0.5.4",
-            "google-proto-files": "0.13.1",
-            "grpc": "1.9.0",
-            "is-stream-ended": "0.1.3",
-            "lodash": "4.17.5",
-            "process-nextick-args": "1.0.7",
-            "protobufjs": "6.8.4",
-            "readable-stream": "2.3.3",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "google-proto-files": {
-              "version": "0.13.1",
-              "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.13.1.tgz",
-              "integrity": "sha512-CivI3rZ85dMPTCAyxq6lq9s7vDkeWEIFxweopC1vEjjRmFMJwOX/MOmFZ90a0BGal/Dsb63vq7Ael9ryeokz0g=="
-            }
-          }
-        },
-        "google-proto-files": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.12.1.tgz",
-          "integrity": "sha512-d+BiTMpYP4/pN+Kgi0lWE+2/GaVN4jy8LCabjo2Wd16Ykm5oRO5bI40bo8u2U4rN/GpZkMyfxZAjWVPRjGe3nQ=="
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "protobufjs": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
-          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.9.1",
-            "long": "3.2.0"
-          }
-        }
-      }
-    },
-    "@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
-    },
-    "@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
-    },
-    "@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-      "requires": {
-        "@protobufjs/aspromise": "1.1.2",
-        "@protobufjs/inquire": "1.1.0"
-      }
-    },
-    "@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
-    },
-    "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
-    },
-    "@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
-    },
-    "@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
-    },
-    "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
-    },
-    "@types/long": {
-      "version": "3.0.32",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
-      "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
-    },
-    "@types/node": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.1.tgz",
-      "integrity": "sha512-4JFGIC1RSoFngVsT5EZcL793/uRi/OJ3ilsp9DQUr4LZOaMhNM1pPrt9TqlXOnXj3h73hl6NF31v87eQAPXYTg=="
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
-    "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-    },
-    "acorn-es7-plugin": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz",
-      "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s="
     },
     "ajv": {
       "version": "5.5.2",
@@ -2347,7 +202,7 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
+        "fast-deep-equal": "1.1.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
@@ -2360,8 +215,7 @@
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "anymatch": {
       "version": "1.3.2",
@@ -2373,11 +227,6 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
-    },
-    "arguejs": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/arguejs/-/arguejs-0.2.3.tgz",
-      "integrity": "sha1-tvk59f4OPNHz+T4qqSYkJL8xKvc="
     },
     "arr-diff": {
       "version": "2.0.0",
@@ -2393,19 +242,6 @@
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
-    },
-    "array-filter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -2423,15 +259,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
-    "ascli": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
-      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-      "requires": {
-        "colour": "0.7.1",
-        "optjs": "3.2.2"
-      }
-    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -2443,27 +270,31 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
       }
     },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true,
+      "optional": true
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "attempt-x": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.1.tgz",
-      "integrity": "sha512-hIp37ojJRRW8ExWSxxLpkDHUufk/DFfsb7/cUC1cVbBg7JV4gJTkCTRa44dlL9e5jx1P3VNrjL7QOQfi4MyltA=="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -2471,9 +302,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -3340,17 +1171,13 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base64url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -3363,49 +1190,19 @@
       "dev": true,
       "optional": true
     },
-    "bl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "2.16.3"
       }
     },
     "brace-expansion": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.10.tgz",
       "integrity": "sha512-u0KjSZq9NOEh36yRmKT/pIYOu0rpGAyUTeUmJgNd1K2tpAaUomh092TZ0fqbBGQc4hz85BVngAiB2mqekvQvIw==",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -3433,72 +1230,15 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
-      "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
-      "requires": {
-        "is-array-buffer-x": "1.7.0"
-      }
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
     },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
-    },
-    "bun": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/bun/-/bun-0.0.12.tgz",
-      "integrity": "sha512-Toms18J9DqnT+IfWkwxVTB2EaBprHvjlMWrTIsfX4xbu3ZBqVBwrERU0em1IgtRe04wT+wJxMlKHZok24hrcSQ==",
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
-    "bytebuffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
-      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
-      "requires": {
-        "long": "3.2.0"
-      }
-    },
-    "cached-constructors-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cached-constructors-x/-/cached-constructors-x-1.0.0.tgz",
-      "integrity": "sha512-JVP0oilYlPgBTD8bkQ+of7hSIJRtydCCJiMtzdRMXVQ98gdj0NyrJTZzbu5wtlO26Ev/1HXRTtbBNsVlLJ3+3A=="
-    },
-    "call-signature": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
-    },
-    "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -3514,24 +1254,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
         "has-ansi": "2.0.0",
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
-      }
-    },
-    "checkpoint-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/checkpoint-stream/-/checkpoint-stream-0.1.1.tgz",
-      "integrity": "sha1-WQiFEfviO20sHoLq8C8oRZZn9jc=",
-      "requires": {
-        "events-intercept": "2.0.0",
-        "pumpify": "1.4.0",
-        "split-array-stream": "1.0.3",
-        "through2": "2.0.3"
       }
     },
     "chokidar": {
@@ -3552,204 +1280,10 @@
         "readdirp": "2.1.0"
       }
     },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
-    "codecov.io": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/codecov.io/-/codecov.io-0.0.1.tgz",
-      "integrity": "sha1-JeorCV4enqEYcr36WEIRgTDfeLE=",
-      "requires": {
-        "request": "2.42.0",
-        "urlgrey": "0.4.0"
-      },
-      "dependencies": {
-        "asn1": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-          "optional": true
-        },
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-          "optional": true
-        },
-        "boom": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-          "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-          "requires": {
-            "hoek": "0.9.1"
-          }
-        },
-        "caseless": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
-          "integrity": "sha1-gWfBq4OX+1u5X5bSjlqBxQ8kesQ="
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-          "optional": true,
-          "requires": {
-            "delayed-stream": "0.0.5"
-          }
-        },
-        "cryptiles": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-          "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
-          "optional": true,
-          "requires": {
-            "boom": "0.4.2"
-          }
-        },
-        "delayed-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-          "optional": true
-        },
-        "forever-agent": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-          "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
-        },
-        "form-data": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-          "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
-          "optional": true,
-          "requires": {
-            "async": "0.9.2",
-            "combined-stream": "0.0.7",
-            "mime": "1.2.11"
-          }
-        },
-        "hawk": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-          "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
-          "optional": true,
-          "requires": {
-            "boom": "0.4.2",
-            "cryptiles": "0.2.2",
-            "hoek": "0.9.1",
-            "sntp": "0.2.4"
-          }
-        },
-        "hoek": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
-        },
-        "http-signature": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-          "optional": true,
-          "requires": {
-            "asn1": "0.1.11",
-            "assert-plus": "0.1.5",
-            "ctype": "0.5.3"
-          }
-        },
-        "mime": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
-          "optional": true
-        },
-        "mime-types": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-          "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "oauth-sign": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
-          "integrity": "sha1-8ilW8x6nFRqCHl8vsywRPK2Ln2k=",
-          "optional": true
-        },
-        "qs": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
-          "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
-        },
-        "request": {
-          "version": "2.42.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
-          "integrity": "sha1-VyvQFIk4VkBArHqxSLlkI6BjMEo=",
-          "requires": {
-            "aws-sign2": "0.5.0",
-            "bl": "0.9.5",
-            "caseless": "0.6.0",
-            "forever-agent": "0.5.2",
-            "form-data": "0.1.4",
-            "hawk": "1.1.1",
-            "http-signature": "0.10.1",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "1.0.2",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.4.0",
-            "qs": "1.2.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3"
-          }
-        },
-        "sntp": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-          "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
-          "optional": true,
-          "requires": {
-            "hoek": "0.9.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-        }
-      }
     },
     "color-convert": {
       "version": "1.9.1",
@@ -3766,15 +1300,10 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "colour": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
-    },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -3782,32 +1311,40 @@
     "commander": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
-      "dev": true
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
+        "buffer-from": "1.1.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+          "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+        }
       }
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
+        "make-dir": "1.3.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -3843,21 +1380,11 @@
       }
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
+        "boom": "2.10.1"
       }
     },
     "crypto-rand": {
@@ -3869,17 +1396,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
-    },
-    "ctype": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
-      "optional": true
-    },
-    "d64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
-      "integrity": "sha1-QAKofoUMv8n52XBrYPymE6MzbpA="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -3897,34 +1413,10 @@
         "ms": "2.0.0"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
-    "deep-equal": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
-      "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84="
-    },
-    "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
-    },
-    "defined": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -3940,25 +1432,6 @@
         "repeating": "2.0.1"
       }
     },
-    "diff-match-patch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
-      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg="
-    },
-    "dir-glob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-      "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
-      }
-    },
-    "dns-zonefile": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/dns-zonefile/-/dns-zonefile-0.1.18.tgz",
-      "integrity": "sha1-dWnHNx29/VC/jlPi2gdAZ5KSKZ4="
-    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -3967,26 +1440,16 @@
         "is-obj": "1.0.1"
       }
     },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
-    },
     "duplexify": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
-      "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
         "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "stream-shift": "1.0.0"
       }
-    },
-    "eastasianwidth": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.1.1.tgz",
-      "integrity": "sha1-RNZW3p2kFWlEZzNTZfsxR7hXK3w="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -3998,30 +1461,11 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "base64url": "2.0.0",
         "safe-buffer": "5.1.1"
-      }
-    },
-    "empower": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
-      "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
-      "requires": {
-        "core-js": "2.5.3",
-        "empower-core": "0.6.2"
-      }
-    },
-    "empower-core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
-      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
-      "requires": {
-        "call-signature": "0.0.2",
-        "core-js": "2.5.3"
       }
     },
     "end-of-stream": {
@@ -4041,6 +1485,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
       }
@@ -4048,8 +1493,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint-scope": {
       "version": "3.7.1",
@@ -4067,14 +1511,6 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
     },
-    "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
-      "requires": {
-        "core-js": "2.5.3"
-      }
-    },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
@@ -4088,27 +1524,14 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
-    },
-    "eventid": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/eventid/-/eventid-0.1.2.tgz",
-      "integrity": "sha1-CyMtPiROpbHVKJhBQOpprH7IkhU=",
-      "requires": {
-        "d64": "1.0.0",
-        "uuid": "3.2.1"
-      }
-    },
-    "events-intercept": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/events-intercept/-/events-intercept-2.0.0.tgz",
-      "integrity": "sha1-rb84aBxaSyARxB7kH2GjTLpEiJc="
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -4148,9 +1571,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -4200,24 +1623,19 @@
         "for-in": "1.0.2"
       }
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
       }
     },
     "fs-readdir-recursive": {
@@ -4229,7 +1647,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.1.3",
@@ -5135,118 +2554,168 @@
         }
       }
     },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
-    },
-    "gce-images": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/gce-images/-/gce-images-0.3.3.tgz",
-      "integrity": "sha512-J+/kX80uYl8sz0zT1P9KlLzMBpzC6rSFFwh3BSXMNfZsVk3r0hXBj/mUOKiJ8EUVjs7AbeGFGLCS8Pz3LhfccA==",
-      "requires": {
-        "arrify": "1.0.1",
-        "async": "1.5.2",
-        "google-auto-auth": "0.7.2",
-        "got": "4.2.0",
-        "object-assign": "3.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
-          "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
-          "requires": {
-            "async": "2.6.0",
-            "gcp-metadata": "0.3.1",
-            "google-auth-library": "0.10.0",
-            "request": "2.83.0"
-          },
-          "dependencies": {
-            "async": {
-              "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-              "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-              "requires": {
-                "lodash": "4.17.5"
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        }
-      }
-    },
     "gcp-metadata": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.3.1.tgz",
       "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
       "requires": {
         "extend": "3.0.1",
-        "retry-request": "3.3.1"
+        "retry-request": "3.3.2"
       }
     },
     "gcs-resumable-upload": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.8.2.tgz",
-      "integrity": "sha512-PBl1OFABYxubxfYPh000I0+JLbQzBRtNqxzgxYboIQk2tdw7BvjJ2dVukk3YH4QM6GiUwqItyNqWBuxjLH8GhA==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.7.7.tgz",
+      "integrity": "sha1-2clyWvlwu8hsvwr+8kBtwizpGGQ=",
       "requires": {
         "buffer-equal": "1.0.0",
-        "configstore": "3.1.1",
-        "google-auto-auth": "0.7.2",
-        "pumpify": "1.4.0",
-        "request": "2.83.0",
-        "stream-events": "1.0.2",
+        "configstore": "3.1.2",
+        "google-auto-auth": "0.6.1",
+        "pumpify": "1.5.1",
+        "request": "2.87.0",
+        "stream-events": "1.0.4",
         "through2": "2.0.3"
       },
       "dependencies": {
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "gcp-metadata": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.1.0.tgz",
+          "integrity": "sha1-q+IfHqMk3Qs0o/BsqBdj+x7uN9k=",
+          "requires": {
+            "extend": "3.0.1",
+            "retry-request": "1.3.2"
           }
         },
         "google-auto-auth": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
-          "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.6.1.tgz",
+          "integrity": "sha1-wF2CDpRUc57PKKiJLuqz0WJPLLM=",
           "requires": {
-            "async": "2.6.0",
-            "gcp-metadata": "0.3.1",
+            "async": "2.6.1",
+            "gcp-metadata": "0.1.0",
             "google-auth-library": "0.10.0",
-            "request": "2.83.0"
+            "object-assign": "3.0.0",
+            "request": "2.87.0"
           }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.14.1",
+            "is-my-json-valid": "2.17.2",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+        },
+        "retry-request": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-1.3.2.tgz",
+          "integrity": "sha1-Wa0k5x+K4/MS1fe0vPRnpeWle9Y=",
+          "requires": {
+            "request": "2.76.0",
+            "through2": "2.0.3"
+          },
+          "dependencies": {
+            "request": {
+              "version": "2.76.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
+              "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.7.0",
+                "caseless": "0.11.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "2.0.6",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "node-uuid": "1.4.8",
+                "oauth-sign": "0.8.2",
+                "qs": "6.3.2",
+                "stringstream": "0.0.6",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.4.3"
+              }
+            }
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
         }
       }
     },
-    "generic-pool": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.1.tgz",
-      "integrity": "sha512-xlWAyJMFhjrHYYxoQqT8YQprhSJgMb1AwZjvSzAH8xJEeXpPOWl1zj03heMdJVfa/34BZSclzvGUOaA9qcyIKw=="
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -5260,6 +2729,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -5294,29 +2764,15 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
-    "globby": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-      "requires": {
-        "array-union": "1.0.2",
-        "dir-glob": "2.0.0",
-        "glob": "7.1.2",
-        "ignore": "3.3.7",
-        "pify": "3.0.0",
-        "slash": "1.0.0"
-      }
-    },
     "google-auth-library": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
-      "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
+      "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
       "requires": {
         "gtoken": "1.2.3",
-        "jws": "3.1.4",
-        "lodash.isstring": "4.0.1",
-        "lodash.merge": "4.6.1",
-        "request": "2.83.0"
+        "jws": "3.1.5",
+        "lodash.noop": "3.0.1",
+        "request": "2.87.0"
       }
     },
     "google-auto-auth": {
@@ -5324,838 +2780,22 @@
       "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.8.2.tgz",
       "integrity": "sha512-W91J1paFbyG45gpDWdTu9tKDxbiTDWYkOAxytNVF4oHVVgTCBV/8+lWdjj/6ldjN3eb+sEd9PKJBjm0kmCxvcw==",
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "gcp-metadata": "0.3.1",
         "google-auth-library": "0.12.0",
-        "request": "2.83.0"
-      }
-    },
-    "google-cloud": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/google-cloud/-/google-cloud-0.57.0.tgz",
-      "integrity": "sha1-r+wKoY7K5TnBotJVVtcM152H3+U=",
-      "requires": {
-        "@google-cloud/bigquery": "0.9.6",
-        "@google-cloud/bigtable": "0.10.2",
-        "@google-cloud/compute": "0.8.0",
-        "@google-cloud/datastore": "1.3.3",
-        "@google-cloud/dlp": "0.1.3",
-        "@google-cloud/dns": "0.6.2",
-        "@google-cloud/firestore": "0.8.2",
-        "@google-cloud/language": "0.12.1",
-        "@google-cloud/logging": "1.1.2",
-        "@google-cloud/monitoring": "0.3.0",
-        "@google-cloud/prediction": "0.6.2",
-        "@google-cloud/pubsub": "0.14.8",
-        "@google-cloud/resource": "0.7.3",
-        "@google-cloud/spanner": "0.7.1",
-        "@google-cloud/speech": "0.10.3",
-        "@google-cloud/storage": "1.5.2",
-        "@google-cloud/translate": "1.1.0",
-        "@google-cloud/video-intelligence": "0.3.2",
-        "@google-cloud/vision": "0.12.0",
-        "extend": "3.0.1"
-      }
-    },
-    "google-gax": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.14.5.tgz",
-      "integrity": "sha512-3A6KbrtLDavrqZnnzurnSydRIJnyH+2Sm56fAvXciQ/62aEnSDaR43MCgWhtReCLVjeFjBiCEIdX5zV0LVLVBg==",
-      "requires": {
-        "extend": "3.0.1",
-        "globby": "7.1.1",
-        "google-auto-auth": "0.9.3",
-        "google-proto-files": "0.14.2",
-        "grpc": "1.7.3",
-        "is-stream-ended": "0.1.3",
-        "lodash": "4.17.5",
-        "protobufjs": "6.8.4",
-        "readable-stream": "2.3.3",
-        "through2": "2.0.3"
+        "request": "2.87.0"
       },
       "dependencies": {
-        "gcp-metadata": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.4.1.tgz",
-          "integrity": "sha512-yFE7v+NyoMiTOi2L6r8q87eVbiZCKooJNPKXTHhBStga8pwwgWofK9iHl00qd0XevZxcpk7ORaEL/ALuTvlaGQ==",
+        "google-auth-library": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
+          "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
           "requires": {
-            "extend": "3.0.1",
-            "retry-request": "3.3.1"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.3.tgz",
-          "integrity": "sha512-TbOZZs0WJOolrRmdQLK5qmWdOJQFG1oPnxcIBbAwL7XCWcv3XgZ9gHJ6W4byrdEZT8TahNFgMfkHd73mqxM9dw==",
-          "requires": {
-            "async": "2.6.0",
-            "gcp-metadata": "0.4.1",
-            "google-auth-library": "0.12.0",
-            "request": "2.83.0"
-          }
-        },
-        "google-proto-files": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.14.2.tgz",
-          "integrity": "sha512-wwm2TIlfTgAjDbjrxAb3akznO7vBM0PRLS6Xf2QfR3L7b0p+szD3iwOW0wMSFl3B0UbLv27hUVk+clePqCVmXA==",
-          "requires": {
-            "globby": "7.1.1",
-            "power-assert": "1.4.4",
-            "prettier": "1.10.2",
-            "protobufjs": "6.8.4"
-          }
-        },
-        "grpc": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.3.tgz",
-          "integrity": "sha512-7zXQJlDXMr/ZaDqdaIchgclViyoWo8GQxZSmFUAxR8GwSr28b6/BTgF221WG+2W693jpp74XJ/+I9DcPXsgt9Q==",
-          "requires": {
-            "arguejs": "0.2.3",
-            "lodash": "4.17.5",
-            "nan": "2.8.0",
-            "node-pre-gyp": "0.6.39",
-            "protobufjs": "5.0.2"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.9",
-              "bundled": true
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.3"
-              }
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            },
-            "boom": {
-              "version": "2.10.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "bundled": true,
-              "requires": {
-                "boom": "2.10.1"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "detect-libc": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
-              }
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.1",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "bundled": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "bundled": true,
-              "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "bundled": true
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "node-pre-gyp": {
-              "version": "0.6.39",
-              "bundled": true,
-              "requires": {
-                "detect-libc": "1.0.2",
-                "hawk": "3.1.3",
-                "mkdirp": "0.5.1",
-                "nopt": "4.0.1",
-                "npmlog": "4.1.2",
-                "rc": "1.2.2",
-                "request": "2.81.0",
-                "rimraf": "2.6.2",
-                "semver": "5.4.1",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.1"
-              },
-              "dependencies": {
-                "nopt": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "abbrev": "1.0.9",
-                    "osenv": "0.1.4"
-                  }
-                }
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "protobufjs": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
-              "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
-              "requires": {
-                "ascli": "1.0.1",
-                "bytebuffer": "5.0.1",
-                "glob": "7.1.1",
-                "yargs": "3.32.0"
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true
-            },
-            "rc": {
-              "version": "1.2.2",
-              "bundled": true,
-              "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.2",
-              "bundled": true,
-              "requires": {
-                "glob": "7.1.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "semver": {
-              "version": "5.4.1",
-              "bundled": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "bundled": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              }
-            },
-            "tar-pack": {
-              "version": "3.4.1",
-              "bundled": true,
-              "requires": {
-                "debug": "2.6.8",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.3.3",
-                "rimraf": "2.6.2",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "bundled": true,
-              "requires": {
-                "string-width": "1.0.2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "protobufjs": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
-          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.9.1",
-            "long": "3.2.0"
+            "gtoken": "1.2.3",
+            "jws": "3.1.5",
+            "lodash.isstring": "4.0.1",
+            "lodash.merge": "4.6.1",
+            "request": "2.87.0"
           }
         }
       }
@@ -6165,49 +2805,7 @@
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
       "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
       "requires": {
-        "node-forge": "0.7.1"
-      }
-    },
-    "google-proto-files": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.13.1.tgz",
-      "integrity": "sha512-CivI3rZ85dMPTCAyxq6lq9s7vDkeWEIFxweopC1vEjjRmFMJwOX/MOmFZ90a0BGal/Dsb63vq7Ael9ryeokz0g=="
-    },
-    "got": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-4.2.0.tgz",
-      "integrity": "sha1-r1n0YYNL+v1yLLoBrPTBSp3V2gY=",
-      "requires": {
-        "create-error-class": "2.0.1",
-        "duplexify": "3.5.3",
-        "is-plain-obj": "1.1.0",
-        "is-redirect": "1.0.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "node-status-codes": "1.0.0",
-        "object-assign": "3.0.0",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "1.0.0",
-        "prepend-http": "1.0.4",
-        "read-all-stream": "3.1.0",
-        "timed-out": "2.0.0",
-        "unzip-response": "1.0.2"
-      },
-      "dependencies": {
-        "create-error-class": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-2.0.1.tgz",
-          "integrity": "sha1-qHWe1cjSFKRh6B0Y5wqssz3WPJw=",
-          "requires": {
-            "capture-stack-trace": "1.0.0",
-            "inherits": "2.0.3"
-          }
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        }
+        "node-forge": "0.7.5"
       }
     },
     "graceful-fs": {
@@ -6215,734 +2813,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "grpc": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.9.0.tgz",
-      "integrity": "sha512-F4j7ireH/ssXcBNTGR3yFjRHTWdJmtg6Czm5tnQYwIuhZh4znx8KhA50dpAkjNqrrbzt97N6hd/TXOPTZGmvtQ==",
-      "requires": {
-        "lodash": "4.17.5",
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39",
-        "protobufjs": "5.0.2"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "bundled": true,
-          "requires": {
-            "detect-libc": "1.0.3",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.2",
-            "rc": "1.2.4",
-            "request": "2.81.0",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.1"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true
-        },
-        "rc": {
-          "version": "1.2.4",
-          "bundled": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.1",
-          "bundled": true,
-          "requires": {
-            "debug": "2.6.9",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.3.3",
-            "rimraf": "2.6.2",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
-    },
     "gtoken": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
       "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
       "requires": {
         "google-p12-pem": "0.1.2",
-        "jws": "3.1.4",
+        "jws": "3.1.5",
         "mime": "1.6.0",
-        "request": "2.83.0"
+        "request": "2.87.0"
       }
     },
     "har-schema": {
@@ -6963,7 +2842,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -6974,29 +2852,6 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "has-own-property-x": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
-      "integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      }
-    },
-    "has-symbol-support-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
-      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA=="
-    },
-    "has-to-string-tag-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-      "requires": {
-        "has-symbol-support-x": "1.4.1"
-      }
-    },
     "hash-stream-validation": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz",
@@ -7006,20 +2861,20 @@
       }
     },
     "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
       }
     },
     "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -7037,11 +2892,6 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
-    "html-tags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.2.0.tgz",
-      "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g="
-    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -7049,33 +2899,19 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "sshpk": "1.14.2"
       }
-    },
-    "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
     },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
-    "infinity-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/infinity-x/-/infinity-x-1.0.0.tgz",
-      "integrity": "sha512-wjy2TupBtZ+aAniKt+xs/PO0xOkuaL6wBysUKbgD7aL1PMW/qY5xXDG59zXZ7dU+gk3zwXOu4yIEWPCEFBTgHQ=="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -7095,32 +2931,16 @@
         "loose-envify": "1.3.1"
       }
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
     "is": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
       "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
     },
-    "is-array-buffer-x": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
-      "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
-      "requires": {
-        "attempt-x": "1.1.1",
-        "has-to-string-tag-x": "1.4.1",
-        "is-object-like-x": "1.6.0",
-        "object-get-own-property-descriptor-x": "3.2.0",
-        "to-string-tag-x": "1.4.2"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -7146,11 +2966,6 @@
       "requires": {
         "builtin-modules": "1.1.1"
       }
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -7179,14 +2994,6 @@
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
-    "is-falsey-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.1.tgz",
-      "integrity": "sha512-XWNZC4A+3FX1ECoMjspuEFgSdio82IWjqY/suE0gZ10QA7nzHd/KraRq7Tc5VEHtFRgTRyTdY6W+ykPrDnyoAQ==",
-      "requires": {
-        "to-boolean-x": "1.0.1"
-      }
-    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -7194,38 +3001,6 @@
       "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
-      }
-    },
-    "is-finite-x": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz",
-      "integrity": "sha512-HyFrxJZsgmP5RtR1PVlVvHSP4VslZOqr4uoq4x3rDrSOFaYp4R9tfmiWtAzQxPzixXhac3cYEno3NuVn0OHk2Q==",
-      "requires": {
-        "infinity-x": "1.0.0",
-        "is-nan-x": "1.0.1"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
-    "is-function-x": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
-      "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
-      "requires": {
-        "attempt-x": "1.1.1",
-        "has-to-string-tag-x": "1.4.1",
-        "is-falsey-x": "1.0.1",
-        "is-primitive": "2.0.0",
-        "normalize-space-x": "3.0.0",
-        "replace-comments-x": "2.0.0",
-        "to-boolean-x": "1.0.1",
-        "to-string-tag-x": "1.4.2"
       }
     },
     "is-glob": {
@@ -7237,38 +3012,21 @@
         "is-extglob": "1.0.0"
       }
     },
-    "is-html": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-html/-/is-html-1.1.0.tgz",
-      "integrity": "sha1-4E8cGNOUhRETlvmgJz6rUa8hhGQ=",
-      "requires": {
-        "html-tags": "1.2.0"
-      }
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
     },
-    "is-index-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
-      "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
+    "is-my-json-valid": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "requires": {
-        "math-clamp-x": "1.2.0",
-        "max-safe-integer": "1.0.1",
-        "to-integer-x": "3.0.0",
-        "to-number-x": "2.0.0",
-        "to-string-symbols-supported-x": "1.0.0"
-      }
-    },
-    "is-nan-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.1.tgz",
-      "integrity": "sha512-VfNJgfuT8USqKCYQss8g7sFvCzDnL+OOVMQoXhVoulZAyp0ZTj3oyZaaPrn2dxepAkKSQI2BiKHbBabX1DqVtw=="
-    },
-    "is-nil-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz",
-      "integrity": "sha512-cfTKWI5iSR04SSCzzugTH5tS2rYG7kwI8yl/AqWkyuxZ7k55cbA47Y7Lezdg1N9aaELd+UxLg628bdQeNQ6BUw==",
-      "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-number": {
@@ -7285,20 +3043,6 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
-    "is-object-like-x": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz",
-      "integrity": "sha512-mc3dBMv1jEOdk0f1i2RkJFsZDux0MuHqGwHOoRo770ShUOf4VE6tWThAW8dAZARr9a5RN+iNX1yzMDA5ad1clQ==",
-      "requires": {
-        "is-function-x": "3.3.0",
-        "is-primitive": "2.0.0"
-      }
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -7308,32 +3052,18 @@
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
     },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-stream-ended": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.3.tgz",
-      "integrity": "sha1-oEc7Jnx1ZjVIa+7cfjNE5UnRUqw="
-    },
-    "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -7425,15 +3155,10 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -7447,23 +3172,21 @@
       }
     },
     "jwa": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
       "requires": {
-        "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.9",
+        "ecdsa-sig-formatter": "1.0.10",
         "safe-buffer": "5.1.1"
       }
     },
     "jws": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "base64url": "2.0.0",
-        "jwa": "1.1.5",
+        "jwa": "1.1.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -7474,14 +3197,6 @@
       "dev": true,
       "requires": {
         "is-buffer": "1.1.6"
-      }
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "1.0.0"
       }
     },
     "load-json-file": {
@@ -7533,22 +3248,8 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-    },
-    "lodash.chunk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-    },
-    "lodash.isnull": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
-      "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4="
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
@@ -7565,28 +3266,15 @@
       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
       "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
     },
-    "lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
-    },
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "log-driver": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.6.tgz",
-      "integrity": "sha512-iUHz4WAGsXwUmL1UergWrkFD2iTUrGLMsQDRYUWtS9FI+wSyM76vIL+THQt7vrQq5fZDGdrPSCFUfIlqII28tg==",
-      "requires": {
-        "codecov.io": "0.0.1"
-      }
-    },
-    "long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -7597,52 +3285,12 @@
         "js-tokens": "3.0.2"
       }
     },
-    "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
-    },
     "make-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
         "pify": "3.0.0"
-      }
-    },
-    "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
-    },
-    "math-clamp-x": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
-      "requires": {
-        "to-number-x": "2.0.0"
-      }
-    },
-    "math-sign-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
-      "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
-      "requires": {
-        "is-nan-x": "1.0.1",
-        "to-number-x": "2.0.0"
-      }
-    },
-    "max-safe-integer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
-      "integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA="
-    },
-    "merge-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-      "requires": {
-        "readable-stream": "2.3.3"
       }
     },
     "methmeth": {
@@ -7677,22 +3325,23 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "1.33.0"
       }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.10"
       }
@@ -7725,27 +3374,14 @@
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
-    },
-    "nan-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nan-x/-/nan-x-1.0.0.tgz",
-      "integrity": "sha512-yw4Fhe2/UTzanQ4f0yHWkRnfTuHZFAi4GZDjXS4G+qv5BqXTqPJBbSxpa7MyyW9v4Y4ZySZQik1vcbNkhdnIOg=="
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true,
+      "optional": true
     },
     "node-forge": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
-      "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
-    },
-    "node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
-    },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -7768,20 +3404,11 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
-    "normalize-space-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
-      "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "trim-x": "3.0.0",
-        "white-space-x": "3.0.0"
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -7792,28 +3419,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-get-own-property-descriptor-x": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
-      "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
-      "requires": {
-        "attempt-x": "1.1.1",
-        "has-own-property-x": "3.2.0",
-        "has-symbol-support-x": "1.4.1",
-        "is-falsey-x": "1.0.1",
-        "is-index-x": "1.1.0",
-        "is-primitive": "2.0.0",
-        "is-string": "1.0.4",
-        "property-is-enumerable-x": "1.1.0",
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      }
-    },
-    "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "object.omit": {
       "version": "2.0.1",
@@ -7833,24 +3438,11 @@
         "wrappy": "1.0.2"
       }
     },
-    "optjs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
-    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "1.0.0"
-      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -7905,21 +3497,11 @@
         "is-glob": "2.0.1"
       }
     },
-    "parse-int-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
-      "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "nan-x": "1.0.0",
-        "to-string-x": "1.4.2",
-        "trim-left-x": "3.0.0"
-      }
-    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "1.3.1"
       }
@@ -7933,7 +3515,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-parser": {
       "version": "4.0.4",
@@ -7941,14 +3524,6 @@
       "integrity": "sha512-U71kuqOWLb/syIOvL3PuuoMYy1j9M709F3VfS8MqmSy+gTnIwY5CXuASKlhs+5DDAkmuDIML3vdW7Pna28E/cg==",
       "requires": {
         "search-params": "2.1.2"
-      }
-    },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "requires": {
-        "pify": "3.0.0"
       }
     },
     "performance-now": {
@@ -7962,142 +3537,23 @@
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-      "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-      "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "1.0.0"
+        "pinkie": "2.0.4"
       }
-    },
-    "power-assert": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.4.4.tgz",
-      "integrity": "sha1-kpXqdDcZb1pgH95CDwQmMRhtdRc=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "empower": "1.2.3",
-        "power-assert-formatter": "1.4.1",
-        "universal-deep-strict-equal": "1.2.2",
-        "xtend": "4.0.1"
-      }
-    },
-    "power-assert-context-formatter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
-      "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
-      "requires": {
-        "core-js": "2.5.3",
-        "power-assert-context-traversal": "1.1.1"
-      }
-    },
-    "power-assert-context-reducer-ast": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.1.2.tgz",
-      "integrity": "sha1-SEqZ4m9Jc/+IMuXFzHVnAuYJQXQ=",
-      "requires": {
-        "acorn": "4.0.13",
-        "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.3",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
-      }
-    },
-    "power-assert-context-traversal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
-      "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
-      "requires": {
-        "core-js": "2.5.3",
-        "estraverse": "4.2.0"
-      }
-    },
-    "power-assert-formatter": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
-      "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
-      "requires": {
-        "core-js": "2.5.3",
-        "power-assert-context-formatter": "1.1.1",
-        "power-assert-context-reducer-ast": "1.1.2",
-        "power-assert-renderer-assertion": "1.1.1",
-        "power-assert-renderer-comparison": "1.1.1",
-        "power-assert-renderer-diagram": "1.1.2",
-        "power-assert-renderer-file": "1.1.1"
-      }
-    },
-    "power-assert-renderer-assertion": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.1.1.tgz",
-      "integrity": "sha1-y/wOd+AIao+Wrz8djme57n4ozpg=",
-      "requires": {
-        "power-assert-renderer-base": "1.1.1",
-        "power-assert-util-string-width": "1.1.1"
-      }
-    },
-    "power-assert-renderer-base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-base/-/power-assert-renderer-base-1.1.1.tgz",
-      "integrity": "sha1-lqZQxv0F7hvB9mtUrWFELIs/Y+s="
-    },
-    "power-assert-renderer-comparison": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
-      "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
-      "requires": {
-        "core-js": "2.5.3",
-        "diff-match-patch": "1.0.0",
-        "power-assert-renderer-base": "1.1.1",
-        "stringifier": "1.3.0",
-        "type-name": "2.0.2"
-      }
-    },
-    "power-assert-renderer-diagram": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
-      "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
-      "requires": {
-        "core-js": "2.5.3",
-        "power-assert-renderer-base": "1.1.1",
-        "power-assert-util-string-width": "1.1.1",
-        "stringifier": "1.3.0"
-      }
-    },
-    "power-assert-renderer-file": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.1.1.tgz",
-      "integrity": "sha1-o34rvReMys0E5427eckv40kzxec=",
-      "requires": {
-        "power-assert-renderer-base": "1.1.1"
-      }
-    },
-    "power-assert-util-string-width": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.1.1.tgz",
-      "integrity": "sha1-vmWet5N/3S5smncmjar2S9W3xZI=",
-      "requires": {
-        "eastasianwidth": "0.1.1"
-      }
-    },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
-    },
-    "prettier": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
-      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg=="
     },
     "private": {
       "version": "0.1.8",
@@ -8110,36 +3566,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
-    "prop-assign": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prop-assign/-/prop-assign-1.0.0.tgz",
-      "integrity": "sha1-l2eh+/1wk5CGR6boRtMbT+qnBFk="
-    },
-    "property-is-enumerable-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
-      "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
-      "requires": {
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      }
-    },
-    "propprop": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/propprop/-/propprop-0.3.1.tgz",
-      "integrity": "sha1-oEmjVouJZEAGfRXY7J8zc15XAXg="
-    },
-    "protobufjs": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
-      "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
-      "requires": {
-        "ascli": "1.0.1",
-        "bytebuffer": "5.0.1",
-        "glob": "7.1.2",
-        "yargs": "3.32.0"
-      }
-    },
     "pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -8150,11 +3576,11 @@
       }
     },
     "pumpify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
-      "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "requires": {
-        "duplexify": "3.5.3",
+        "duplexify": "3.6.0",
         "inherits": "2.0.3",
         "pump": "2.0.1"
       }
@@ -8165,9 +3591,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
       "version": "5.1.0",
@@ -8216,30 +3642,6 @@
           "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
-          }
-        }
-      }
-    },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
           }
         }
       }
@@ -8454,51 +3856,31 @@
         "is-finite": "1.0.2"
       }
     },
-    "replace-comments-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
-      "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
-      "requires": {
-        "require-coercible-to-string-x": "1.0.0",
-        "to-string-x": "1.4.2"
-      }
-    },
     "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
         "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
+        "aws4": "1.7.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
+        "form-data": "2.3.2",
         "har-validator": "5.0.3",
-        "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
+        "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
-      }
-    },
-    "require-coercible-to-string-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.0.tgz",
-      "integrity": "sha512-Rpfd4sMdflPAKecdKhfAtQHlZzzle4UMUgxJ01hXtTcNWMV8w9GeZnKhEyrT73kgrflBOP1zg41amUPZGcNspA==",
-      "requires": {
-        "require-object-coercible-x": "1.4.1",
-        "to-string-x": "1.4.2"
+        "uuid": "3.3.2"
       }
     },
     "require-main-filename": {
@@ -8507,33 +3889,17 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
-    "require-object-coercible-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.1.tgz",
-      "integrity": "sha512-0YHa2afepsLfQvwQ1P2XvDZnGOUia5sC07ZijIRU2dnsRxnuilXWF6B2CFaKGDA9eZl39lJHrXCDsnfgroRd6Q==",
-      "requires": {
-        "is-nil-x": "1.4.1"
-      }
-    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
-    "resumer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
     "retry-request": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
-      "integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.2.tgz",
+      "integrity": "sha512-WIiGp37XXDC6e7ku3LFoi7LCL/Gs9luGeeqvbPRb+Zl6OQMw4RCRfSaW+aLfE6lhz1R941UavE6Svl3Dm5xGIQ==",
       "requires": {
-        "request": "2.83.0",
+        "request": "2.87.0",
         "through2": "2.0.3"
       }
     },
@@ -8541,6 +3907,11 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "search-params": {
       "version": "2.1.2",
@@ -8568,28 +3939,15 @@
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
-    },
-    "snakecase-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-1.1.0.tgz",
-      "integrity": "sha1-GtsX3fdTHCEMwpMzb5PQ7x+Oc7g=",
-      "requires": {
-        "map-obj": "2.0.0",
-        "to-snake-case": "0.1.2"
-      }
-    },
-    "snakeize": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
-      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
     },
     "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "2.16.3"
       }
     },
     "source-map": {
@@ -8628,50 +3986,35 @@
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
-    "split": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
     "split-array-stream": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
       "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
       "requires": {
-        "async": "2.6.0",
-        "is-stream-ended": "0.1.3"
+        "async": "2.6.1",
+        "is-stream-ended": "0.1.4"
       }
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
+        "bcrypt-pbkdf": "1.0.2",
         "dashdash": "1.14.1",
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
       }
     },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "requires": {
-        "duplexer": "0.1.1"
-      }
-    },
     "stream-events": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.2.tgz",
-      "integrity": "sha1-q/OfZsCJCk63lbyNXoWbJhW1kLI=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.4.tgz",
+      "integrity": "sha512-D243NJaYs/xBN2QnoiMDY7IesJFIK7gEhnvAYqJa5JvDdnh2dC4qDBwlCf0ohPpX2QRlA/4gnbnPd3rs3KxVcA==",
       "requires": {
         "stubs": "3.0.0"
       }
@@ -8691,16 +4034,6 @@
       "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.1.tgz",
       "integrity": "sha512-Mm+sROy+pHJmx0P/0Bs1uxIX6UhGJGj6xDGQZ5zh9v/SZRmLGevp+p0VJxV7lirrkAmQ2mvva/gHKpnF/pTb+Q=="
     },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
-      }
-    },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
@@ -8709,20 +4042,10 @@
         "safe-buffer": "5.1.1"
       }
     },
-    "stringifier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
-      "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
-      "requires": {
-        "core-js": "2.5.3",
-        "traverse": "0.6.6",
-        "type-name": "2.0.2"
-      }
-    },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -8749,23 +4072,7 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "tape": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.0.tgz",
-      "integrity": "sha1-Df7scJIn+8yRcKvn8EaWKycUMds=",
-      "requires": {
-        "deep-equal": "0.1.2",
-        "defined": "0.0.0",
-        "inherits": "2.0.3",
-        "jsonify": "0.0.0",
-        "resumer": "0.0.0",
-        "split": "0.2.10",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
-      }
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "test-exclude": {
       "version": "4.1.1",
@@ -8780,11 +4087,6 @@
         "require-main-filename": "1.0.1"
       }
     },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
     "through2": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -8794,148 +4096,18 @@
         "xtend": "4.0.1"
       }
     },
-    "timed-out": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-      "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
-    },
-    "to-boolean-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz",
-      "integrity": "sha512-PstxY3K6hVEHnY3FITs8XBoJbt0RI1e4MLIhAL9hWa3BtVLCrb86vU5z6lEKh7uZZjiPiLqIKMmfMro1nNgtXQ=="
-    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
-    "to-integer-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
-      "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
-      "requires": {
-        "is-finite-x": "3.0.2",
-        "is-nan-x": "1.0.1",
-        "math-sign-x": "3.0.0",
-        "to-number-x": "2.0.0"
-      }
-    },
-    "to-no-case": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-0.1.1.tgz",
-      "integrity": "sha1-zzPHDg8oFo2V5BWavxUOjFQu+f4="
-    },
-    "to-number-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
-      "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "nan-x": "1.0.0",
-        "parse-int-x": "2.0.0",
-        "to-primitive-x": "1.1.0",
-        "trim-x": "3.0.0"
-      }
-    },
-    "to-object-x": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
-      "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "require-object-coercible-x": "1.4.1"
-      }
-    },
-    "to-primitive-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
-      "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
-      "requires": {
-        "has-symbol-support-x": "1.4.1",
-        "is-date-object": "1.0.1",
-        "is-function-x": "3.3.0",
-        "is-nil-x": "1.4.1",
-        "is-primitive": "2.0.0",
-        "is-symbol": "1.0.1",
-        "require-object-coercible-x": "1.4.1",
-        "validate.io-undefined": "1.0.3"
-      }
-    },
-    "to-property-key-x": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
-      "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
-      "requires": {
-        "has-symbol-support-x": "1.4.1",
-        "to-primitive-x": "1.1.0",
-        "to-string-x": "1.4.2"
-      }
-    },
-    "to-snake-case": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-0.1.2.tgz",
-      "integrity": "sha1-0Ee22/BI2uG9wmCzwpb1TKNO7Xw=",
-      "requires": {
-        "to-space-case": "0.1.2"
-      }
-    },
-    "to-space-case": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-0.1.2.tgz",
-      "integrity": "sha1-mma+Pr5T8nefaH8CYu/9H8W20V4=",
-      "requires": {
-        "to-no-case": "0.1.1"
-      }
-    },
-    "to-string-symbols-supported-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-string-symbols-supported-x/-/to-string-symbols-supported-x-1.0.0.tgz",
-      "integrity": "sha512-HbVH673pybrUmhzESGHUm17BBJvqb7BU8HciOvuEYm9ipuDyjmddhvkVqpVW6sM/C5/zhJo17n7O7I/24loJIQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "has-symbol-support-x": "1.4.1",
-        "is-symbol": "1.0.1"
-      }
-    },
-    "to-string-tag-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.2.tgz",
-      "integrity": "sha512-ytO9eLigxsQQLGuab0C1iSSTzKdJNVSlBg0Spg4J/rGAVrQJ5y774mo0SSzgGeTT4RJGGyJNfObXaTMzX0XDOQ==",
-      "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
-      }
-    },
-    "to-string-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.2.tgz",
-      "integrity": "sha512-/WP5arlwtCpAAexCCHiQBW0eXwse84osWyP1Qtaz71nsYSuUpOkT6tBm8nQ4IIUfSh5hji0hDupUCD2xbbOL6A==",
-      "requires": {
-        "is-symbol": "1.0.1"
-      }
-    },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "1.4.1"
-      }
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-    },
-    "trim-left-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
-      "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "require-coercible-to-string-x": "1.0.0",
-        "white-space-x": "3.0.0"
       }
     },
     "trim-right": {
@@ -8943,25 +4115,6 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
-    },
-    "trim-right-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
-      "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "require-coercible-to-string-x": "1.0.0",
-        "white-space-x": "3.0.0"
-      }
-    },
-    "trim-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
-      "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
-      "requires": {
-        "trim-left-x": "3.0.0",
-        "trim-right-x": "3.0.0"
-      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -8972,27 +4125,28 @@
       }
     },
     "tus-js-client": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-1.4.5.tgz",
-      "integrity": "sha1-7lJd+KLE3EETvPkz3dfUCj20O5U=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-1.5.1.tgz",
+      "integrity": "sha512-qBSNXpc6ZPe6stn4NSkQ1dnVhVblPAtQo6037g5Qr5zr9gGX1gr+8e0+HtQMBp22Ouo6LYesWMdKbcOR5sRj5A==",
       "requires": {
-        "buffer-from": "0.1.1",
+        "buffer-from": "0.1.2",
         "extend": "3.0.1",
         "lodash.throttle": "4.1.1",
         "resolve-url": "0.2.1"
       }
     },
     "tus-node-server": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tus-node-server/-/tus-node-server-0.2.8.tgz",
-      "integrity": "sha512-Ge8zziBn02cjjRG+HHOMY0J2JzGbA0fAMBv+M4g8jkTtjRFOlyaynti9hF0s1BKVF1/IKxLkwmZvel8oi2mVMg==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/tus-node-server/-/tus-node-server-0.2.11.tgz",
+      "integrity": "sha512-1Eb/GGejUTUpCpuHbol8OsQDk38Mx8jPLne+0VvPTKVv6Gvoj+Q7trjc5mQHQqCd8vIYsXHEEJ/46YR1bZZJig==",
       "requires": {
-        "configstore": "3.1.1",
+        "@google-cloud/storage": "1.1.1",
+        "configstore": "3.1.2",
         "crypto-rand": "0.0.2",
+        "debug": "3.1.0",
         "google-auto-auth": "0.8.2",
-        "google-cloud": "0.57.0",
         "object-assign": "4.1.1",
-        "request": "2.83.0"
+        "request": "2.87.0"
       }
     },
     "tweetnacl": {
@@ -9000,11 +4154,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
-    },
-    "type-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
-      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -9019,29 +4168,6 @@
         "crypto-random-string": "1.0.0"
       }
     },
-    "universal-deep-strict-equal": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/universal-deep-strict-equal/-/universal-deep-strict-equal-1.2.2.tgz",
-      "integrity": "sha1-DaSsL3PP95JMgfpN4BjKViyisKc=",
-      "requires": {
-        "array-filter": "1.0.0",
-        "indexof": "0.0.1",
-        "object-keys": "1.0.11"
-      }
-    },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-    },
-    "urlgrey": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.0.tgz",
-      "integrity": "sha1-8GU1cED7NcOzEdTl3DZITZbb6gY=",
-      "requires": {
-        "tape": "2.3.0"
-      }
-    },
     "user-home": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
@@ -9054,9 +4180,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
       "version": "2.1.1",
@@ -9077,11 +4203,6 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
-    "validate.io-undefined": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
-      "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q="
-    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -9090,25 +4211,6 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
-      }
-    },
-    "white-space-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-3.0.0.tgz",
-      "integrity": "sha512-nMPVXGMdi/jQepXKryxqzEh/vCwdOYY/u6NZy40glMHvZfEr7/+vQKnDhEq4rZ1nniOFq9GWohQYB30uW/5Olg=="
-    },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -9135,25 +4237,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yargs": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-      "requires": {
-        "camelcase": "2.1.1",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "os-locale": "1.4.0",
-        "string-width": "1.0.2",
-        "window-size": "0.1.4",
-        "y18n": "3.2.1"
-      }
     }
   }
 }

--- a/packages/file-collections/package.json
+++ b/packages/file-collections/package.json
@@ -35,7 +35,9 @@
   "main": "./dist/node/index.js",
   "scripts": {
     "build": "rm -rf dist/** && babel src --out-dir dist --ignore *.test.js,__snapshots__",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "snyk-protect": "snyk protect",
+    "prepare": "npm run snyk-protect"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -44,7 +46,8 @@
     "path-parser": "^4.0.4",
     "query-string": "^5.1.0",
     "tus-js-client": "^1.5.1",
-    "tus-node-server": "^0.2.11"
+    "tus-node-server": "^0.2.11",
+    "snyk": "^1.74.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -57,5 +60,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "snyk": true
 }

--- a/packages/file-collections/package.json
+++ b/packages/file-collections/package.json
@@ -43,8 +43,8 @@
     "debug": "^3.1.0",
     "path-parser": "^4.0.4",
     "query-string": "^5.1.0",
-    "tus-js-client": "^1.4.5",
-    "tus-node-server": "^0.2.8"
+    "tus-js-client": "^1.5.1",
+    "tus-node-server": "^0.2.11"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
## Summary
This commit patches two vulnerable libs with snyk
1. hoek version 2.16.3
2. tunnel-agent version 0.4.3

These patches are added to the .snyk file
It adds a `snyk protect` command that is run during the `prepare` step
to ensure that the patches are applied

## Questions
I'm not certain how these patches will play with the build process. The `snyk protect` command added to the prepare step should run before `npm run build` is completed, but this may not work and it may be better to move these patches to the `reaction` repo and ignore the vulns here until we can update to a good version.