### PR TITLE
fix: update tus-node-server to 0.3.0

### DIFF
--- a/packages/file-collections/package-lock.json
+++ b/packages/file-collections/package-lock.json
@@ -135,67 +135,6 @@
         }
       }
     },
-    "@google-cloud/common": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.13.6.tgz",
-      "integrity": "sha1-qdjhN7xCmkSrqWif5qDkMxeE+FM=",
-      "requires": {
-        "array-uniq": "1.0.3",
-        "arrify": "1.0.1",
-        "concat-stream": "1.6.2",
-        "create-error-class": "3.0.2",
-        "duplexify": "3.6.0",
-        "ent": "2.2.0",
-        "extend": "3.0.1",
-        "google-auto-auth": "0.7.2",
-        "is": "3.2.1",
-        "log-driver": "1.2.7",
-        "methmeth": "1.1.0",
-        "modelo": "4.2.3",
-        "request": "2.87.0",
-        "retry-request": "3.3.2",
-        "split-array-stream": "1.0.3",
-        "stream-events": "1.0.4",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "google-auto-auth": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
-          "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
-          "requires": {
-            "async": "2.6.1",
-            "gcp-metadata": "0.3.1",
-            "google-auth-library": "0.10.0",
-            "request": "2.87.0"
-          }
-        }
-      }
-    },
-    "@google-cloud/storage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.1.1.tgz",
-      "integrity": "sha1-ZZC1zm53lVbJzHBDvWRJ1rwHgd4=",
-      "requires": {
-        "@google-cloud/common": "0.13.6",
-        "arrify": "1.0.1",
-        "async": "2.6.1",
-        "concat-stream": "1.6.2",
-        "create-error-class": "3.0.2",
-        "duplexify": "3.6.0",
-        "extend": "3.0.1",
-        "gcs-resumable-upload": "0.7.7",
-        "hash-stream-validation": "0.2.1",
-        "is": "3.2.1",
-        "mime-types": "2.1.18",
-        "once": "1.4.0",
-        "pumpify": "1.5.1",
-        "stream-events": "1.0.4",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
-      }
-    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -210,12 +149,14 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "anymatch": {
       "version": "1.3.2",
@@ -296,6 +237,29 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "aws-sdk": {
+      "version": "2.278.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.278.1.tgz",
+      "integrity": "sha512-xkiPaLOd1WDad1K9GaJgkP+YukwB3cBGXfYaQZtHtn4wHNdPL1c4vU5WNRGXL/aH8CXtd50c9OGqxUienMpKCQ==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -305,6 +269,15 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "1.5.1",
+        "is-buffer": "1.1.6"
+      }
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -1174,6 +1147,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1189,14 +1167,6 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true,
       "optional": true
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
     },
     "brace-expansion": {
       "version": "1.1.10",
@@ -1219,10 +1189,15 @@
         "repeat-element": "1.1.2"
       }
     },
-    "buffer-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
+      }
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -1254,6 +1229,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
@@ -1311,7 +1287,23 @@
     "commander": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+      "dev": true
+    },
+    "compressible": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
+      "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
+      "requires": {
+        "mime-db": "1.35.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.35.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1377,14 +1369,6 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
         "capture-stack-trace": "1.0.0"
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.10.1"
       }
     },
     "crypto-rand": {
@@ -1493,7 +1477,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint-scope": {
       "version": "3.7.1",
@@ -1532,6 +1517,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -1606,6 +1596,14 @@
       "dev": true,
       "requires": {
         "locate-path": "2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
+      "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+      "requires": {
+        "debug": "3.1.0"
       }
     },
     "for-in": {
@@ -2554,169 +2552,6 @@
         }
       }
     },
-    "gcp-metadata": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.3.1.tgz",
-      "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
-      "requires": {
-        "extend": "3.0.1",
-        "retry-request": "3.3.2"
-      }
-    },
-    "gcs-resumable-upload": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.7.7.tgz",
-      "integrity": "sha1-2clyWvlwu8hsvwr+8kBtwizpGGQ=",
-      "requires": {
-        "buffer-equal": "1.0.0",
-        "configstore": "3.1.2",
-        "google-auto-auth": "0.6.1",
-        "pumpify": "1.5.1",
-        "request": "2.87.0",
-        "stream-events": "1.0.4",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
-          }
-        },
-        "gcp-metadata": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.1.0.tgz",
-          "integrity": "sha1-q+IfHqMk3Qs0o/BsqBdj+x7uN9k=",
-          "requires": {
-            "extend": "3.0.1",
-            "retry-request": "1.3.2"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.6.1.tgz",
-          "integrity": "sha1-wF2CDpRUc57PKKiJLuqz0WJPLLM=",
-          "requires": {
-            "async": "2.6.1",
-            "gcp-metadata": "0.1.0",
-            "google-auth-library": "0.10.0",
-            "object-assign": "3.0.0",
-            "request": "2.87.0"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.14.1",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.2"
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
-        },
-        "retry-request": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-1.3.2.tgz",
-          "integrity": "sha1-Wa0k5x+K4/MS1fe0vPRnpeWle9Y=",
-          "requires": {
-            "request": "2.76.0",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "request": {
-              "version": "2.76.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
-              "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.7.0",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "node-uuid": "1.4.8",
-                "oauth-sign": "0.8.2",
-                "qs": "6.3.2",
-                "stringstream": "0.0.6",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.4.3"
-              }
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-        }
-      }
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "1.0.2"
-      }
-    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -2764,65 +2599,10 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
-    "google-auth-library": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-      "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-      "requires": {
-        "gtoken": "1.2.3",
-        "jws": "3.1.5",
-        "lodash.noop": "3.0.1",
-        "request": "2.87.0"
-      }
-    },
-    "google-auto-auth": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.8.2.tgz",
-      "integrity": "sha512-W91J1paFbyG45gpDWdTu9tKDxbiTDWYkOAxytNVF4oHVVgTCBV/8+lWdjj/6ldjN3eb+sEd9PKJBjm0kmCxvcw==",
-      "requires": {
-        "async": "2.6.1",
-        "gcp-metadata": "0.3.1",
-        "google-auth-library": "0.12.0",
-        "request": "2.87.0"
-      },
-      "dependencies": {
-        "google-auth-library": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
-          "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.5",
-            "lodash.isstring": "4.0.1",
-            "lodash.merge": "4.6.1",
-            "request": "2.87.0"
-          }
-        }
-      }
-    },
-    "google-p12-pem": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
-      "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
-      "requires": {
-        "node-forge": "0.7.5"
-      }
-    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "gtoken": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
-      "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
-      "requires": {
-        "google-p12-pem": "0.1.2",
-        "jws": "3.1.5",
-        "mime": "1.6.0",
-        "request": "2.87.0"
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -2842,6 +2622,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -2859,22 +2640,6 @@
       "requires": {
         "through2": "2.0.3"
       }
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -2901,6 +2666,11 @@
         "jsprim": "1.4.1",
         "sshpk": "1.14.2"
       }
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -2955,8 +2725,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -3012,23 +2781,6 @@
         "is-extglob": "1.0.0"
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-    },
-    "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -3054,11 +2806,6 @@
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-stream-ended": {
       "version": "0.1.4",
@@ -3116,6 +2863,11 @@
         "semver": "5.5.0"
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -3154,11 +2906,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -3256,16 +3003,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
-    "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
-    },
-    "lodash.noop": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
-      "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
-    },
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -3283,6 +3020,15 @@
       "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "make-dir": {
@@ -3318,11 +3064,6 @@
         "parse-glob": "3.0.4",
         "regex-cache": "0.4.4"
       }
-    },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.33.0",
@@ -3536,19 +3277,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "2.0.4"
-      }
-    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -3565,6 +3293,11 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pump": {
       "version": "2.0.1",
@@ -3604,6 +3337,11 @@
         "object-assign": "4.1.1",
         "strict-uri-encode": "1.1.0"
       }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -3894,6 +3632,11 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
+    "retry-axios": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
+      "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
+    },
     "retry-request": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.2.tgz",
@@ -3912,6 +3655,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "search-params": {
       "version": "2.1.2",
@@ -3942,13 +3690,10 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
+    "snakeize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
+      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
     },
     "source-map": {
       "version": "0.5.7",
@@ -4042,15 +3787,11 @@
         "safe-buffer": "5.1.1"
       }
     },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -4072,7 +3813,8 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "test-exclude": {
       "version": "4.1.1",
@@ -4136,17 +3878,143 @@
       }
     },
     "tus-node-server": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/tus-node-server/-/tus-node-server-0.2.11.tgz",
-      "integrity": "sha512-1Eb/GGejUTUpCpuHbol8OsQDk38Mx8jPLne+0VvPTKVv6Gvoj+Q7trjc5mQHQqCd8vIYsXHEEJ/46YR1bZZJig==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tus-node-server/-/tus-node-server-0.3.0.tgz",
+      "integrity": "sha512-ep98ZWtyUh6jzUEMVM4v8pIy/1SGnHl6Jfi1NWeSzAtAivKatu7HqyTuh8ZDNnXasaEAAhqb3aAmD7edg40aSg==",
       "requires": {
-        "@google-cloud/storage": "1.1.1",
+        "@google-cloud/storage": "1.7.0",
+        "aws-sdk": "2.278.1",
         "configstore": "3.1.2",
         "crypto-rand": "0.0.2",
-        "debug": "3.1.0",
-        "google-auto-auth": "0.8.2",
-        "object-assign": "4.1.1",
-        "request": "2.87.0"
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "@google-cloud/common": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.17.0.tgz",
+          "integrity": "sha512-HRZLSU762E6HaKoGfJGa8W95yRjb9rY7LePhjaHK9ILAnFacMuUGVamDbTHu1csZomm1g3tZTtXfX/aAhtie/Q==",
+          "requires": {
+            "array-uniq": "1.0.3",
+            "arrify": "1.0.1",
+            "concat-stream": "1.6.2",
+            "create-error-class": "3.0.2",
+            "duplexify": "3.6.0",
+            "ent": "2.2.0",
+            "extend": "3.0.1",
+            "google-auto-auth": "0.10.1",
+            "is": "3.2.1",
+            "log-driver": "1.2.7",
+            "methmeth": "1.1.0",
+            "modelo": "4.2.3",
+            "request": "2.87.0",
+            "retry-request": "3.3.2",
+            "split-array-stream": "1.0.3",
+            "stream-events": "1.0.4",
+            "string-format-obj": "1.1.1",
+            "through2": "2.0.3"
+          }
+        },
+        "@google-cloud/storage": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.7.0.tgz",
+          "integrity": "sha512-QaAxzCkbhspwajoaEnT0GcnQcpjPRcBrHYuQsXtD05BtOJgVnHCLXSsfUiRdU0nVpK+Thp7+sTkQ0fvk5PanKg==",
+          "requires": {
+            "@google-cloud/common": "0.17.0",
+            "arrify": "1.0.1",
+            "async": "2.6.1",
+            "compressible": "2.0.14",
+            "concat-stream": "1.6.2",
+            "create-error-class": "3.0.2",
+            "duplexify": "3.6.0",
+            "extend": "3.0.1",
+            "gcs-resumable-upload": "0.10.2",
+            "hash-stream-validation": "0.2.1",
+            "is": "3.2.1",
+            "mime": "2.3.1",
+            "mime-types": "2.1.18",
+            "once": "1.4.0",
+            "pumpify": "1.5.1",
+            "request": "2.87.0",
+            "safe-buffer": "5.1.1",
+            "snakeize": "0.1.0",
+            "stream-events": "1.0.4",
+            "through2": "2.0.3",
+            "xdg-basedir": "3.0.0"
+          }
+        },
+        "gcp-metadata": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
+          "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
+          "requires": {
+            "axios": "0.18.0",
+            "extend": "3.0.1",
+            "retry-axios": "0.3.2"
+          }
+        },
+        "gcs-resumable-upload": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.10.2.tgz",
+          "integrity": "sha1-fymz7iPc7EFwNnwHEUGCScZgVF8=",
+          "requires": {
+            "configstore": "3.1.2",
+            "google-auto-auth": "0.10.1",
+            "pumpify": "1.5.1",
+            "request": "2.87.0",
+            "stream-events": "1.0.4"
+          }
+        },
+        "google-auth-library": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
+          "integrity": "sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==",
+          "requires": {
+            "axios": "0.18.0",
+            "gcp-metadata": "0.6.3",
+            "gtoken": "2.3.0",
+            "jws": "3.1.5",
+            "lodash.isstring": "4.0.1",
+            "lru-cache": "4.1.3",
+            "retry-axios": "0.3.2"
+          }
+        },
+        "google-auto-auth": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.10.1.tgz",
+          "integrity": "sha512-iIqSbY7Ypd32mnHGbYctp80vZzXoDlvI9gEfvtl3kmyy5HzOcrZCIGCBdSlIzRsg7nHpQiHE3Zl6Ycur6TSodQ==",
+          "requires": {
+            "async": "2.6.1",
+            "gcp-metadata": "0.6.3",
+            "google-auth-library": "1.6.1",
+            "request": "2.87.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
+          "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
+          "requires": {
+            "node-forge": "0.7.5",
+            "pify": "3.0.0"
+          }
+        },
+        "gtoken": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
+          "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
+          "requires": {
+            "axios": "0.18.0",
+            "google-p12-pem": "1.0.2",
+            "jws": "3.1.5",
+            "mime": "2.3.1",
+            "pify": "3.0.0"
+          }
+        },
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+        }
       }
     },
     "tweetnacl": {
@@ -4166,6 +4034,22 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
         "crypto-random-string": "1.0.0"
+      }
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
       }
     },
     "user-home": {
@@ -4233,10 +4117,29 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.1",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/packages/file-collections/package.json
+++ b/packages/file-collections/package.json
@@ -44,7 +44,7 @@
     "path-parser": "^4.0.4",
     "query-string": "^5.1.0",
     "tus-js-client": "^1.5.1",
-    "tus-node-server": "^0.2.11"
+    "tus-node-server": "^0.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Update tus-node-server from 0.2.11 to 0.3.0 to eliminate remaining dependency introduced vulnerabilities as reported by snyk.

This eliminates the following vulnerabilities: stringstream, base64url, and cryptiles