### PR TITLE
[Meteor App] Insert file record on server side

### DIFF
--- a/example-apps/meteor-blaze-app/imports/client/images/images.js
+++ b/example-apps/meteor-blaze-app/imports/client/images/images.js
@@ -33,10 +33,7 @@ function uploadAndInsertBrowserFile(file) {
   // Do the upload
   uploadInfo.set({ ...uploadInfo.get(), isUploading: true });
   fileRecord.upload({ chunkSize: 1024 * 1024 })
-    .then((id) => {
-      console.log(`Temp ID is ${id}`); // eslint-disable-line no-console
-      return Images.insert(fileRecord);
-    })
+    .then(() => Meteor.call("insertImage", fileRecord.document))
     .then(() => {
       console.log("FileRecord saved to database"); // eslint-disable-line no-console
       return uploadInfo.set({ ...uploadInfo.get(), isUploading: false });

--- a/example-apps/meteor-blaze-app/server/main.js
+++ b/example-apps/meteor-blaze-app/server/main.js
@@ -97,6 +97,10 @@ const Images = new MongoFileCollection("Images", {
 });
 
 Meteor.methods({
+  insertImage(fileRecord) {
+    check(fileRecord, Object);
+    return ImagesCollection.insert(fileRecord);
+  },
   insertRemoteImage(url) {
     check(url, String);
     const fileRecord = Promise.await(FileRecord.fromUrl(url, { fetch }));


### PR DESCRIPTION
As it stands, the example Meteor app doesn't allow uploading images out of the box for me. When I try to do so, the upload goes to 100% and stays stuck there. In the console, I'm getting `Method 'FileCollection/INSERT/Images' not found [404]`. Adding remote images, however, works without any issue.

For some reason, `MeteorFileCollection` doesn't allow inserting file records straight from the client. No idea why that is, but since we're using a `TempFileStoreWorker` on the server side which listens to MongoDB change streams to detect finished uploads, I thought it would be cleaner to just insert the file record on the server side from a Meteor method.

This way, after finishing the upload into the temporary store, we call the `insertImage` Meteor method (instead of our client side `Images.insert()`, and the file gets moved to the permanent stores by `TempFileStoreWorker`.