### PR TITLE
Fix Blob upload

### DIFF
--- a/packages/file-collections/src/common/FileRecord/FileRecord.js
+++ b/packages/file-collections/src/common/FileRecord/FileRecord.js
@@ -131,7 +131,12 @@ export default class FileRecord extends EventEmitter {
 
   attachData(data) {
     if (!data) throw new Error("FileRecord.attachData requires a data argument with some data");
-    this.data = data;
+    if(data instanceof Blob) {
+      this.data = data.stream();
+    }
+    else {
+      this.data = data;
+    }
     return this;
   }
 
@@ -255,6 +260,7 @@ export default class FileRecord extends EventEmitter {
         resume: true,
         retryDelays: [0, 1000, 3000, 5000],
         metadata: { name, size, type },
+        uploadSize: size,
         onError(error) {
           reject(error);
         },

--- a/packages/file-collections/src/common/FileRecord/FileRecord.js
+++ b/packages/file-collections/src/common/FileRecord/FileRecord.js
@@ -131,10 +131,9 @@ export default class FileRecord extends EventEmitter {
 
   attachData(data) {
     if (!data) throw new Error("FileRecord.attachData requires a data argument with some data");
-    if(data instanceof Blob) {
+    if (data instanceof Blob) {
       this.data = data.stream();
-    }
-    else {
+    } else {
       this.data = data;
     }
     return this;


### PR DESCRIPTION
Closes https://github.com/reactioncommerce/reaction-file-collections/issues/36

Use Blob as a stream. That requires converting it to stream and providing `uploadSize` parameter to `tus` (because `size` cannot be computed dynamically in stream scenario)