### PR TITLE
fix: path parser

### DIFF
--- a/packages/file-collections/src/node/getFileDownloadHandler/getFileDownloadHandler.js
+++ b/packages/file-collections/src/node/getFileDownloadHandler/getFileDownloadHandler.js
@@ -1,5 +1,5 @@
 import contentDisposition from "content-disposition";
-import Path from "path-parser";
+import { Path } from "path-parser";
 import debug from "../debug";
 import requestRange from "./requestRange";
 import writeHeadersToResponse from "./writeHeadersToResponse";


### PR DESCRIPTION
close: https://github.com/reactioncommerce/reaction-file-collections/issues/50

Breaking change introduced: Path is a named export rather than the default export.