### PR TITLE
fix: revert to tus-js-client ^1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4540,16 +4540,6 @@
         }
       }
     },
-    "combine-errors": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/combine-errors/-/combine-errors-3.0.3.tgz",
-      "integrity": "sha1-9N9nQAg+VwOjGBEQwrEFUfAD2oY=",
-      "dev": true,
-      "requires": {
-        "custom-error-instance": "2.1.1",
-        "lodash.uniqby": "4.5.0"
-      }
-    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5257,12 +5247,6 @@
       "requires": {
         "array-find-index": "^1.0.1"
       }
-    },
-    "custom-error-instance": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/custom-error-instance/-/custom-error-instance-2.1.1.tgz",
-      "integrity": "sha1-PPY5FIemYppiR+sMoM4ACBt+Nho=",
-      "dev": true
     },
     "cyclist": {
       "version": "1.0.1",
@@ -9821,12 +9805,6 @@
         }
       }
     },
-    "js-base64": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.3.tgz",
-      "integrity": "sha512-fiUvdfCaAXoQTHdKMgTvg6IkecXDcVz6V5rlftUTclF9IKBjMizvSdQaCl/z/6TApDeby5NL+axYou3i0mu1Pg==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10154,57 +10132,11 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
-    "lodash._baseiteratee": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz",
-      "integrity": "sha1-NKm1VDVycnw9sueO2uPA6eZr0QI=",
-      "dev": true,
-      "requires": {
-        "lodash._stringtopath": "~4.8.0"
-      }
-    },
-    "lodash._basetostring": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
-      "integrity": "sha1-kyfJ3FFYhmt/pLnUL0Y45XZt2d8=",
-      "dev": true
-    },
-    "lodash._baseuniq": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
-      "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
-      "dev": true,
-      "requires": {
-        "lodash._createset": "~4.0.0",
-        "lodash._root": "~3.0.0"
-      }
-    },
-    "lodash._createset": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-      "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
-      "dev": true
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
-    },
-    "lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-      "dev": true
-    },
-    "lodash._stringtopath": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz",
-      "integrity": "sha1-lBvPDmQmbl/B1m/tCmlZVExXaCQ=",
-      "dev": true,
-      "requires": {
-        "lodash._basetostring": "~4.12.0"
-      }
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -10255,27 +10187,11 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
-      "dev": true
-    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
-    },
-    "lodash.uniqby": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.5.0.tgz",
-      "integrity": "sha1-o6F7v2LutiQPSRhG6XwcTipeHiE=",
-      "dev": true,
-      "requires": {
-        "lodash._baseiteratee": "~4.7.0",
-        "lodash._baseuniq": "~4.6.0"
-      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -11569,16 +11485,6 @@
         "react-is": "^16.8.1"
       }
     },
-    "proper-lockfile": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.1.tgz",
-      "integrity": "sha1-FZ+wYZPTIAP0s2kd0uwaY0qoDR0=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "retry": "^0.10.0"
-      }
-    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -11666,12 +11572,6 @@
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }
-    },
-    "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-      "dev": true
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -12056,12 +11956,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
@@ -13148,28 +13042,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "tus-js-client": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-2.1.1.tgz",
-      "integrity": "sha512-ILpgHlR0nfKxmlkXfrZ2z61upkHEXhADOGbGyvXSPjp7bn1NhU50p/Mu59q577Xirayr9vlW4tmoFqUrHKcWeQ==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^0.1.1",
-        "combine-errors": "^3.0.3",
-        "js-base64": "^2.4.9",
-        "lodash.throttle": "^4.1.1",
-        "proper-lockfile": "^2.0.1",
-        "url-parse": "^1.4.3"
-      },
-      "dependencies": {
-        "buffer-from": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
-          "dev": true
-        }
-      }
-    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -13364,16 +13236,6 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
-    },
-    "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-      "dev": true,
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "eslint-plugin-react-hooks": "^4.0.8",
     "jest": "^26.1.0",
     "jest-cli": "^26.1.0",
-    "lerna": "^3.22.1",
-    "tus-js-client": "^2.1.1"
+    "lerna": "^3.22.1"
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.10.5",

--- a/packages/file-collections/package-lock.json
+++ b/packages/file-collections/package-lock.json
@@ -3609,9 +3609,9 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-base64": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.3.tgz",
-      "integrity": "sha512-fiUvdfCaAXoQTHdKMgTvg6IkecXDcVz6V5rlftUTclF9IKBjMizvSdQaCl/z/6TApDeby5NL+axYou3i0mu1Pg=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4221,9 +4221,9 @@
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "readable-stream": {
       "version": "2.3.3",
@@ -4843,12 +4843,13 @@
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tus-js-client": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-2.1.1.tgz",
-      "integrity": "sha512-ILpgHlR0nfKxmlkXfrZ2z61upkHEXhADOGbGyvXSPjp7bn1NhU50p/Mu59q577Xirayr9vlW4tmoFqUrHKcWeQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-1.8.0.tgz",
+      "integrity": "sha512-qPX3TywqzxocTxUZtcS8X7Aik72SVMa0jKi4hWyfvRV+s9raVzzYGaP4MoJGaF0yOgm2+b6jXaVEHogxcJ8LGw==",
       "requires": {
         "buffer-from": "^0.1.1",
         "combine-errors": "^3.0.3",
+        "extend": "^3.0.2",
         "js-base64": "^2.4.9",
         "lodash.throttle": "^4.1.1",
         "proper-lockfile": "^2.0.1",

--- a/packages/file-collections/package.json
+++ b/packages/file-collections/package.json
@@ -72,7 +72,7 @@
     "extend": "~3.0.2",
     "path-parser": "^6.1.0",
     "query-string": "^6.13.1",
-    "tus-js-client": "^2.1.1",
+    "tus-js-client": "^1.5.1",
     "tus-node-server": "~0.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- This will likely f i x https://github.com/reactioncommerce/reaction/issues/6298
- Update to tus-js-client 2.x was semver major and likely broke image uploads
- base package.json does not actually need this at all as a dependency
- only packages/file-collections needs it
- fresh npm install to update package-lock.json resolves to
tus-js-client v1.8.0, which hopefully works