### PR TITLE
fix: Ignore undefined errors from stream.destroy()

### DIFF
--- a/packages/file-collections-sa-base/src/StorageAdapter.js
+++ b/packages/file-collections-sa-base/src/StorageAdapter.js
@@ -200,7 +200,7 @@ export default class StorageAdapter extends EventEmitter {
         })
         .catch((error) => {
           debug("saveCopyInfo error", error);
-          emitError(new Error(`StorageAdapter error saving copy info: ${error.message}`));
+          emitError(new Error(`StorageAdapter error saving copy info: ${error && (error.message || "error is undefined")}`));
         });
     });
 

--- a/packages/file-collections/src/common/FileCollection.js
+++ b/packages/file-collections/src/common/FileCollection.js
@@ -82,7 +82,11 @@ export default class FileCollection extends EventEmitter {
     return (error, fileRecord) => {
       // When a file has an error while being stored into the temp store, we emit an "error" event on the FS.Collection only if the file belongs to this collection
       if (fileRecord.collectionName === this.name) {
-        const storeError = new Error(`Error from ${storeName} store: ${error.message}`);
+        if (!error) {
+          // Nothing to be done about empty errors from stream.destroy() calls
+          return;
+        }
+        const storeError = new Error(`Error from ${storeName} store: ${error && (error.message || "error is undefined")}`);
         this.emit("error", storeError, fileRecord, storeName);
       }
     };

--- a/packages/file-collections/src/common/FileRecord/FileRecord.js
+++ b/packages/file-collections/src/common/FileRecord/FileRecord.js
@@ -353,7 +353,7 @@ export default class FileRecord extends EventEmitter {
       const writeStream = await store.createWriteStream(cloneRecord, { skipTransform: true });
 
       return new Promise((resolve, reject) => {
-        writeStream.once("error", reject);
+        writeStream.once("error", (err) => err && reject(err));
         writeStream.once("stored", resolve);
         readStream.pipe(writeStream);
       });

--- a/packages/file-collections/src/node/RemoteUrlWorker.js
+++ b/packages/file-collections/src/node/RemoteUrlWorker.js
@@ -132,7 +132,7 @@ export default class RemoteUrlWorker extends EventEmitter {
         const readStream = response.body;
         const writeStream = await store.createWriteStream(fileRecord);
         const promise = new Promise((resolve, reject) => {
-          fileRecord.once("error", reject);
+          fileRecord.once("error", (err) => err && reject(err));
           fileRecord.once("stored", resolve);
           readStream.pipe(writeStream);
         });


### PR DESCRIPTION
- This relates to https://github.com/reactioncommerce/reaction/issues/6298
- Our underlying GridFSStream is getting .destroy() called
- That in turn emits an "error" event with no arguments
- Many places in the code were assuming an error instance would be passed
- Fix is to not assume that and not propagate such undefined errors

I have tested that I can create a new product, set only the title, save it, and I can add images to both the top product and the default variant that gets created along with it. All sizes are generated, URLs are populated, and images are served properly.

